### PR TITLE
fix: remove slash from marketplace plugin name

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
-  "name": "first-fluke/oh-my-agent",
+  "name": "oh-my-agent",
   "owner": {
     "name": "First Fluke",
     "url": "https://github.com/first-fluke"


### PR DESCRIPTION
The marketplace name field does not support owner/repo format with
slashes. Changed from "first-fluke/oh-my-agent" to "oh-my-agent"
to match the convention used by other plugins (e.g., "omc",
"opsx-omc-bridge").