### PR TITLE
fix(cli): checkSqlInjection grep command has unterminated shell quoting

### DIFF
--- a/cli/commands/verify/verify.ts
+++ b/cli/commands/verify/verify.ts
@@ -210,7 +210,7 @@ function checkPythonSyntax(workspace: string): VerifyCheck {
 
 function checkSqlInjection(workspace: string): VerifyCheck {
   const result = runCommand(
-    `grep -rn --include="*.py" -E "f['"].*SELECT|f['"].*INSERT|f['"].*UPDATE|f['"].*DELETE" . 2>/dev/null | grep -v test | grep -v node_modules | head -1`,
+    `grep -rn --include="*.py" -E "f[\\"'].*(SELECT|INSERT|UPDATE|DELETE)" . 2>/dev/null | grep -v test | grep -v node_modules | head -1`,
     workspace,
   );
   if (result) {


### PR DESCRIPTION
## Summary

`checkSqlInjection()` in `cli/commands/verify/verify.ts:213` builds a shell command whose double-quoted `-E` argument terminates early because of an unescaped `"` inside the regex character class. `/bin/sh -c` rejects the string with a syntax error, `runCommand` catches the throw and returns `null`, and the verifier concludes **"None detected" (PASS)** for every input — including real Python f-string SQL concatenation.

The check has never actually run.

## Affected file

- `cli/commands/verify/verify.ts:211-224` (`checkSqlInjection`)

## Reproduction

The current command string (the template literal at line 213 produces this verbatim — backticks don't process `\` or `"`):

```bash
CMD='grep -rn --include="*.py" -E "f['"'"'"].*SELECT|f['"'"'"].*INSERT|f['"'"'"].*UPDATE|f['"'"'"].*DELETE" . 2>/dev/null | grep -v test | grep -v node_modules | head -1'

echo "$CMD" | sh -n
# sh: line 1: unexpected EOF while looking for matching `"'
# sh: line 2: syntax error: unexpected end of file
# Exit: 2
```

`runCommand` (line 52-62) wraps `execSync` in a blanket `try/catch` returning `null`, so the syntax error is swallowed and `if (result)` at line 216 takes the PASS branch.

End-to-end confirmed with a `bad.py` containing `query = f"SELECT * FROM users WHERE id = {uid}"` — the current command returns `null` and the check passes.

## Root cause

Inside a shell double-quoted string, `"` terminates the quote (single quotes don't help either, because they don't escape inside DQ). Tracing the shell state machine through the arg after `-E`:

```
"f['"].*SELECT|f['"].*INSERT|f['"].*UPDATE|f['"].*DELETE"
^    ^         ^             ^                            ^
DQ   DQ(end)   pipe metachar SQ/DQ flip-flops             DQ(never closed)
```

- The first inner `"` closes the outer DQ after `f['`
- `|` is no longer quoted → becomes a pipeline metacharacter
- Subsequent fragments toggle between `'...'` and `"..."` states
- The final `"` after `DELETE` re-opens DQ and the string ends mid-quote → `unexpected EOF while looking for matching ` followed by a lone `"`

## Fix

Escape the inner `"` with `\"` (template-literal source: `\\"`) and factor the common `f[...]` prefix out of the alternation:

```diff
 function checkSqlInjection(workspace: string): VerifyCheck {
   const result = runCommand(
-    `grep -rn --include="*.py" -E "f['"].*SELECT|f['"].*INSERT|f['"].*UPDATE|f['"].*DELETE" . 2>/dev/null | grep -v test | grep -v node_modules | head -1`,
+    `grep -rn --include="*.py" -E "f[\\"'].*(SELECT|INSERT|UPDATE|DELETE)" . 2>/dev/null | grep -v test | grep -v node_modules | head -1`,
     workspace,
   );
```

After the change, `grep` receives the argument `f["'].*(SELECT|INSERT|UPDATE|DELETE)` — a valid ERE that matches both `f"..."` and `f'...'` followed by any SQL keyword.

## Verification

Sample files:

- `bad.py`: `q = f"SELECT * FROM t WHERE id = {x}"`  → flagged ✓
- `bad2.py`: `q = f'UPDATE t SET x = {v}'`  → flagged ✓
- `good.py`: `q = "SELECT * FROM t WHERE id = ?"`  → not flagged ✓

Local checks:

- `bun run build` → ✅ passes
- `bun run test` → 28 failing tests in `__tests__/test-filter.test.ts`, all reproducible on clean `main` (verified with `git stash`). Unrelated to this change.
- `bun run lint` → `cli` lint passes (`Checked 206 files, No fixes applied`); the subsequent `bun run --cwd web lint` fails with `Script not found "lint"`, also present on clean `main`. Unrelated to this change.

## Scope

- One-line change in `cli/commands/verify/verify.ts`
- No public API surface affected
- Happy to add a small fixture under `cli/__tests__/` that asserts the check flags a known f-string query if that fits the test layout.

## Note on categorization

I'm not filing this as a security advisory because `oma verify` is a developer-facing lint helper, not a runtime security gate. The defect is that the advertised check does not actually run.