### PR TITLE
feat(image): add --reference flag with sanitized unique filenames

### DIFF
--- a/.agents/skills/oma-image/SKILL.md
+++ b/.agents/skills/oma-image/SKILL.md
@@ -80,6 +80,7 @@ oma image generate "<prompt>" [--vendor auto|codex|pollinations|gemini|all] [-n 
                              [--size 1024x1024|1024x1536|1536x1024|auto] \
                              [--quality low|medium|high|auto] \
                              [--out <dir>] [--allow-external-out] \
+                             [-r <path>...] \
                              [--timeout 180] [-y] [--no-prompt-in-manifest] \
                              [--dry-run] [--format text|json]
 oma image doctor
@@ -87,6 +88,28 @@ oma image list-vendors
 ```
 
 Gemini-only escalation flag: `--strategy mcp,stream,api` (overrides `vendors.gemini.strategies`).
+
+### Reference Images (`-r`, `--reference`)
+
+Attach up to 10 reference images (PNG/JPEG/GIF/WebP, ≤ 5MB each) to guide style, subject identity, or composition. Repeatable or comma-separated.
+
+```
+oma image generate -r ~/Downloads/otter.jpeg "same otter in dramatic lighting"
+oma image generate -r a.png -r b.png "blend these two styles"
+```
+
+Supported vendors:
+
+| Vendor | Support | How |
+|--------|---------|-----|
+| `codex` (gpt-image-2) | ✅ | Passes `-i <path>` to `codex exec` |
+| `gemini` (2.5-flash-image) | ✅ | Inlines base64 `inlineData` parts in request |
+| `pollinations` | ❌ | Rejected with exit code 4 (requires URL hosting; see PR #2 roadmap) |
+
+**Paths**: absolute or relative to `$CWD`. Host CLIs usually expose attached images via:
+- **Claude Code**: `~/.claude/image-cache/<session>/N.png` (surfaced in system messages as `[Image: source: <path>]`)
+- **Antigravity**: workspace upload directory (exact path shown in IDE)
+- **Codex CLI as host**: user must pass the filesystem path explicitly; in-conversation attachments are not forwarded
 
 ### Shared Infrastructure (from other skills)
 

--- a/.agents/skills/oma-image/SKILL.md
+++ b/.agents/skills/oma-image/SKILL.md
@@ -80,7 +80,7 @@ oma image generate "<prompt>" [--vendor auto|codex|pollinations|gemini|all] [-n 
                              [--size 1024x1024|1024x1536|1536x1024|auto] \
                              [--quality low|medium|high|auto] \
                              [--out <dir>] [--allow-external-out] \
-                             [-r <path>...] \
+                             [-r <path>]... \
                              [--timeout 180] [-y] [--no-prompt-in-manifest] \
                              [--dry-run] [--format text|json]
 oma image doctor

--- a/.agents/skills/oma-image/SKILL.md
+++ b/.agents/skills/oma-image/SKILL.md
@@ -57,11 +57,13 @@ Skip both clarification and amplification when the user has clearly authored a f
 
 ## Vendors
 
-| Vendor | Primary Strategy | Models | Trigger |
-|--------|-----------------|--------|---------|
-| `codex` | `codex exec` (OAuth via ChatGPT subscription) → built-in `image_gen` | `gpt-image-2` | Logged into Codex CLI |
-| `pollinations` | `gen.pollinations.ai/v1/images/generations` (OpenAI-compatible) | Free: `flux`, `zimage`. Credit-gated (requires pollen balance): `qwen-image`, `wan-image`, `gpt-image-2`, `klein`, `kontext`, `gptimage`, `gptimage-large` | `POLLINATIONS_API_KEY` is set (free key at https://enter.pollinations.ai) |
-| `gemini` | `@google/genai` SDK (direct API) | `gemini-2.5-flash-image`, `gemini-3.1-flash-image-preview` | `GEMINI_API_KEY` set + billing activated on AI Studio account |
+This skill follows oh-my-agent's CLI-first concept: whenever a vendor's native CLI can drive generation (and return raw bytes), the subprocess path is preferred over direct API keys. Direct API is only used as a fallback for vendors whose CLI can't yet emit raw image bytes.
+
+| Vendor | Strategy | Models | Trigger |
+|--------|----------|--------|---------|
+| `codex` | CLI-first — `codex exec` via ChatGPT OAuth (`codex login`), built-in `image_gen` | `gpt-image-2` | Logged in via Codex CLI (no API key) |
+| `pollinations` | Direct HTTP — `gen.pollinations.ai/v1/images/generations` (free signup for key) | Free: `flux`, `zimage`. Credit-gated: `qwen-image`, `wan-image`, `gpt-image-2`, `klein`, `kontext`, `gptimage`, `gptimage-large` | `POLLINATIONS_API_KEY` set (free at https://enter.pollinations.ai). No native CLI exists. |
+| `gemini` | CLI-first fallback → direct API. `gemini -p` (stream) is the preferred path but currently disabled at precheck (CLI's agentic loop does not return raw `inlineData` bytes on stdout as of Gemini CLI 0.38). Until the CLI exposes a non-agentic image surface, the provider falls back to the direct `generativelanguage.googleapis.com` API. | `gemini-2.5-flash-image`, `gemini-3.1-flash-image-preview` | Preferred: `gemini auth login`. Fallback: `GEMINI_API_KEY` + billing. |
 
 ## Invocation
 

--- a/.agents/skills/oma-image/resources/execution-protocol.md
+++ b/.agents/skills/oma-image/resources/execution-protocol.md
@@ -13,7 +13,32 @@ Run the **Clarification Protocol** in `SKILL.md` before shelling out.
    - `size` ∈ {`1024x1024`, `1024x1536`, `1536x1024`, `auto`}
    - `quality` ∈ {`low`, `medium`, `high`, `auto`}
    - `vendor` ∈ {`auto`, `codex`, `pollinations`, `gemini`, `all`} or a concrete registered name.
+   - `reference` (if any): each path exists, is a regular file ≤ 5MB, magic-byte-matches PNG/JPEG/GIF/WebP, ≤ 10 total, and duplicate paths are rejected with exit 4.
 4. If invalid: exit code 4 and a message identifying the offending field.
+
+## Step 0.5: Reference Image Handling
+
+When `--reference <path...>` is supplied:
+
+1. Validate every path via `reference-guard.ts`. On failure → exit 4.
+2. Reject the request if the selected vendor(s) do not support references (currently only `codex` and `gemini`). Pollinations returns exit 4 with a hint to switch vendor.
+3. Pass validated absolute paths through `GenerateInput.referenceImages`:
+   - `codex` provider appends `-i <path>` per reference to `codex exec` and adds a guidance sentence to the instruction text.
+   - `gemini` api strategy reads each file, base64-encodes it, and prepends `{ inlineData: { mimeType, data } }` parts before the text prompt.
+4. Record reference paths in `manifest.json` under `reference_images` (top-level array of absolute paths).
+
+### Host-Specific Reference Paths
+
+Agents invoking `oma image generate --reference` should surface the following host-specific locations to the user:
+
+| Host CLI | Attachment Surface | Path pattern |
+|----------|--------------------|--------------|
+| **Claude Code** | `[Image: source: ...]` in system messages | `~/.claude/image-cache/<session-uuid>/<N>.png` (undocumented, verified empirically; cache is cleared on session end) |
+| **Antigravity IDE** | Workspace upload via "Upload to Agent" | Project workspace upload dir; exact path shown in IDE file tree |
+| **Codex CLI as host** | `-i` flag attaches to LLM context only | No filesystem path exposed. User must provide an explicit path (e.g., `~/Downloads/foo.png`). In-conversation pastes cannot be forwarded. |
+| **Gemini CLI as host** | Varies by version | Prefer explicit paths over paste |
+
+Agents should prefer user-supplied explicit paths (e.g., `~/Downloads/otter.jpeg`) over host-cache paths when durability across sessions matters.
 
 ## Step 1: Vendor Selection
 

--- a/.agents/skills/oma-image/resources/vendor-matrix.md
+++ b/.agents/skills/oma-image/resources/vendor-matrix.md
@@ -1,5 +1,15 @@
 # Vendor Matrix
 
+## Reference Image Support (`--reference` / `-r`)
+
+| Vendor | Reference input | Transport | Notes |
+|--------|-----------------|-----------|-------|
+| `codex` | ✅ | `codex exec -i <path>` (repeatable) | Local file path; 5MB-per-file cap enforced by Codex CLI |
+| `gemini` | ✅ | `inlineData` parts (base64) prepended to text prompt | Up to 14 refs supported by `gemini-2.5-flash-image`; OMA caps at 10 |
+| `pollinations` | ❌ | — | Requires URL hosting; rejected with exit 4. Planned for PR #2. |
+
+All paths are validated in `reference-guard.ts` (magic-byte MIME check + size + count + duplicate rejection) before dispatch. The magic-byte-detected MIME is threaded through `GenerateInput.referenceImages` and used verbatim at the vendor API boundary — file extension is never trusted for MIME type.
+
 ## Codex
 
 | Field | Value |

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Pick a preset and you're ready:
 | **oma-architecture** | Architectural tradeoffs, boundaries, ADR/ATAM/CBAM-aware analysis |
 | **oma-backend** | APIs in Python, Node.js, or Rust |
 | **oma-brainstorm** | Explores ideas before you commit to building |
+| **oma-coordination** | Manual step-by-step multi-agent coordination guide |
 | **oma-db** | Schema design, migrations, indexing, vector DB |
 | **oma-debug** | Root cause analysis, fixes, regression tests |
 | **oma-design** | Design systems, tokens, accessibility, responsive |
@@ -101,16 +102,22 @@ Or use slash commands for structured workflows:
 
 | Step | Command | What It Does |
 |------|---------|-------------|
+| 0 | `/deepinit` | Bootstrap an existing codebase (AGENTS.md, ARCHITECTURE.md, `docs/`) |
 | 1 | `/brainstorm` | Free-form ideation |
 | 2 | `/architecture` | Software architecture review, tradeoffs, ADR/ATAM/CBAM-style analysis |
 | 2 | `/design` | 7-phase design system workflow |
 | 2 | `/plan` | PM breaks down your feature into tasks |
+| 2 | `/exec-plan` | Track plans as first-class artifacts in `docs/exec-plans/` |
+| 2 | `/stack-set` | Auto-detect tech stack, generate language-specific backend resources |
 | 3 | `/work` | Step-by-step multi-agent execution |
 | 3 | `/orchestrate` | Automated parallel agent spawning |
 | 3 | `/ultrawork` | 5-phase quality workflow with 11 review gates |
+| 3 | `/ralph` | Wraps `/ultrawork` in an independent verifier loop until criteria pass |
 | 4 | `/review` | Security + performance + accessibility audit |
 | 5 | `/debug` | Structured root-cause debugging |
 | 6 | `/scm` | SCM + Git workflow and Conventional Commit support |
+| ⚙ | `/tools` | Toggle MCP tool groups (memory / code-analysis / code-edit / file-ops) |
+| 📄 | `/pdf` | PDF → Markdown via `opendataloader-pdf` |
 
 **Auto-detection**: You don't even need slash commands — keywords like "architecture", "plan", "review", and "debug" in your message (in 11 languages!) auto-activate the right workflow.
 
@@ -126,6 +133,11 @@ oma dashboard               # Real-time agent monitoring
 oma link                    # Regenerate .claude/.codex/.gemini/etc. from .agents/
 oma agent:spawn backend "Build auth API" session-01
 oma agent:parallel -i backend:"Auth API" frontend:"Login form"
+oma retro 7d --compare      # Engineering retrospective with metrics + trends
+oma recap --window 1d       # Cross-tool conversation history recap
+oma search fetch <url>      # Mechanical search with auto-escalating strategies
+oma image generate "cat"    # Multi-vendor AI image generation
+oma export cursor           # Project skills as `.cursor/rules` for external IDEs
 ```
 
 Model selection follows two layers:

--- a/cli/commands/image/cost.test.ts
+++ b/cli/commands/image/cost.test.ts
@@ -68,6 +68,33 @@ describe("estimateCost", () => {
     expect(total).toBeCloseTo(0.24, 5);
   });
 
+  it("applies per-reference surcharge for gemini only", () => {
+    const providers = [new StubProvider("codex"), new StubProvider("gemini")];
+    const modelByVendor = {
+      codex: "gpt-image-2",
+      gemini: "gemini-2.5-flash-image",
+    };
+    const totalNoRef = estimateCost({
+      config: stubConfig,
+      providers,
+      modelByVendor,
+      quality: "high",
+      count: 1,
+      referenceCount: 0,
+    });
+    const totalWithRef = estimateCost({
+      config: stubConfig,
+      providers,
+      modelByVendor,
+      quality: "high",
+      count: 1,
+      referenceCount: 2,
+    });
+    // codex $0.04 + gemini $0.04 = $0.08 base; gemini surcharge $0.01 * 2 = $0.02
+    expect(totalNoRef).toBeCloseTo(0.08, 5);
+    expect(totalWithRef).toBeCloseTo(0.1, 5);
+  });
+
   it("falls back to auto when quality key missing", () => {
     const providers = [new StubProvider("codex")];
     const total = estimateCost({

--- a/cli/commands/image/cost.ts
+++ b/cli/commands/image/cost.ts
@@ -8,7 +8,13 @@ export interface EstimateArgs {
   modelByVendor: Record<string, string | undefined>;
   quality: string;
   count: number;
+  referenceCount?: number;
 }
+
+// Gemini 2.5 Flash Image charges ~1,290 input tokens per reference image.
+// At $30/1M output tokens (1,290 tokens ≈ $0.04), we approximate the input
+// surcharge conservatively as $0.01 per reference per generated image.
+const GEMINI_REFERENCE_SURCHARGE_USD = 0.01;
 
 export function estimateCost({
   config,
@@ -16,6 +22,7 @@ export function estimateCost({
   modelByVendor,
   quality,
   count,
+  referenceCount = 0,
 }: EstimateArgs): number {
   let total = 0;
   for (const p of providers) {
@@ -26,6 +33,9 @@ export function estimateCost({
       config.costGuardrail.perImageUsd[p.name]?.[model]?.auto ??
       0;
     total += perImage * count;
+    if (referenceCount > 0 && p.name === "gemini") {
+      total += GEMINI_REFERENCE_SURCHARGE_USD * referenceCount * count;
+    }
   }
   return total;
 }

--- a/cli/commands/image/generate.ts
+++ b/cli/commands/image/generate.ts
@@ -135,15 +135,39 @@ export async function runGenerate({
 
   // `auto` mode: drop reference-unsupported vendors from the healthy set so
   // a pollinations-only-healthy environment doesn't block codex/gemini refs.
+  // Two distinct failure modes to distinguish here:
+  //   (a) no reference-supporting vendor is even installed/authenticated at
+  //       all — surface the per-vendor health hints via printAuthFailure so
+  //       the user sees which ones need setup (exit 5, auth-required).
+  //   (b) reference-supporting vendors exist but only non-supporting ones
+  //       (pollinations) are currently healthy — user's --reference choice
+  //       is invalid given the available vendors (exit 4, invalid-input,
+  //       matching the explicit --vendor pollinations -r X path).
   if (references.length > 0 && vendorFlag === "auto") {
     const droppable = runProviders.filter((p) => !supportsReference(p.name));
     runProviders = runProviders.filter((p) => supportsReference(p.name));
     if (runProviders.length === 0) {
+      const refSupportingHealthResults = healthResults.filter((r) =>
+        supportsReference(r.provider.name),
+      );
+      if (refSupportingHealthResults.length === 0) {
+        // (a) no reference-supporting vendor registered at all
+        console.error(
+          color.red(
+            `--reference is not supported by any registered vendor (${droppable
+              .map((p) => p.name)
+              .join(
+                ", ",
+              )}). Install/enable codex or gemini, or drop --reference.`,
+          ),
+        );
+        return 4;
+      }
+      // (b) ref-supporting vendors exist but none healthy — show their hints
+      printAuthFailure(refSupportingHealthResults, msgs);
       console.error(
-        color.red(
-          `--reference is not supported by any available vendor (${droppable
-            .map((p) => p.name)
-            .join(", ")}). Authenticate codex or gemini, or drop --reference.`,
+        color.yellow(
+          `(${droppable.map((p) => p.name).join(", ")} is healthy but does not support --reference.)`,
         ),
       );
       return 5;

--- a/cli/commands/image/generate.ts
+++ b/cli/commands/image/generate.ts
@@ -136,13 +136,14 @@ export async function runGenerate({
   // `auto` mode: drop reference-unsupported vendors from the healthy set so
   // a pollinations-only-healthy environment doesn't block codex/gemini refs.
   // Two distinct failure modes to distinguish here:
-  //   (a) no reference-supporting vendor is even installed/authenticated at
-  //       all — surface the per-vendor health hints via printAuthFailure so
-  //       the user sees which ones need setup (exit 5, auth-required).
-  //   (b) reference-supporting vendors exist but only non-supporting ones
-  //       (pollinations) are currently healthy — user's --reference choice
-  //       is invalid given the available vendors (exit 4, invalid-input,
+  //   (a) reference-supporting vendors (codex, gemini) are not even
+  //       registered in defaultRegistry — user's --reference choice is
+  //       invalid given the available vendors (exit 4, invalid-input,
   //       matching the explicit --vendor pollinations -r X path).
+  //   (b) reference-supporting vendors are registered but none are
+  //       currently healthy — surface each vendor's own health hint via
+  //       printAuthFailure so the user sees exactly what setup is missing
+  //       (exit 5, auth-required).
   if (references.length > 0 && vendorFlag === "auto") {
     const droppable = runProviders.filter((p) => !supportsReference(p.name));
     runProviders = runProviders.filter((p) => supportsReference(p.name));

--- a/cli/commands/image/generate.ts
+++ b/cli/commands/image/generate.ts
@@ -6,6 +6,10 @@ import { writeManifest } from "./manifest.js";
 import { getMessages } from "./messages.js";
 import { makeRunId } from "./naming.js";
 import { resolveOutDir } from "./path-guard.js";
+import {
+  type ValidatedReference,
+  validateReferenceImages,
+} from "./reference-guard.js";
 import { defaultRegistry } from "./registry.js";
 import {
   exitForError,
@@ -52,11 +56,45 @@ export async function runGenerate({
     return 4;
   }
 
+  const referenceInput = normalizeReferenceOption(opts.reference);
+  let references: ValidatedReference[] = [];
+  if (referenceInput.length > 0) {
+    try {
+      references = await validateReferenceImages(referenceInput);
+    } catch (err) {
+      if (err && typeof err === "object" && (err as VendorError).kind) {
+        const ve = err as VendorError;
+        console.error(
+          color.red(
+            `invalid --reference: ${ve.kind === "invalid-input" ? ve.reason : String(ve.kind)}`,
+          ),
+        );
+      } else {
+        console.error(color.red((err as Error).message));
+      }
+      return 4;
+    }
+  }
+
   const providers = defaultRegistry().list();
   const requested = resolveRequestedProviders(vendorFlag, providers);
   if (requested.length === 0) {
     console.error(color.red(msgs.unknownVendor(vendorFlag)));
     return 4;
+  }
+
+  if (references.length > 0) {
+    const unsupported = requested.filter((p) => !supportsReference(p.name));
+    if (unsupported.length > 0) {
+      console.error(
+        color.red(
+          `--reference is not supported by vendor(s): ${unsupported
+            .map((p) => p.name)
+            .join(", ")}. Use --vendor codex or --vendor gemini.`,
+        ),
+      );
+      return 4;
+    }
   }
 
   const healthResults = await Promise.all(
@@ -116,6 +154,7 @@ export async function runGenerate({
     modelByVendor,
     quality,
     count,
+    referenceCount: references.length,
   });
 
   const plan = {
@@ -128,6 +167,7 @@ export async function runGenerate({
     outDir,
     costEstimate,
     timeoutSec,
+    referenceImages: references.map((r) => r.absolutePath),
   };
 
   if (dryRun) {
@@ -164,6 +204,12 @@ export async function runGenerate({
       msgs.heartbeat(runProviders.map((p) => p.name).join("+"), elapsed),
   });
 
+  const referenceImages =
+    references.length > 0
+      ? references.map((r) => ({ path: r.absolutePath, mime: r.mime }))
+      : undefined;
+  const referenceImagePaths = referenceImages?.map((r) => r.path);
+
   const outcomes = await Promise.allSettled(
     runProviders.map((p) =>
       runSingleProvider({
@@ -177,6 +223,8 @@ export async function runGenerate({
           outDir,
           signal: controller.signal,
           timeoutSec,
+          referenceImages,
+          runShortid: runId.shortid,
         },
       }),
     ),
@@ -209,6 +257,7 @@ export async function runGenerate({
     costEstimate,
     runs,
     startedAt,
+    referenceImages: referenceImagePaths,
   });
 
   const successes = runs.filter((r) => r.status === "ok");
@@ -345,6 +394,26 @@ function resolveRequestedProviders(
 ): VendorProvider[] {
   if (vendorFlag === "auto" || vendorFlag === "all") return providers;
   return providers.filter((p) => p.name === vendorFlag);
+}
+
+function normalizeReferenceOption(raw: unknown): string[] {
+  if (!raw) return [];
+  if (Array.isArray(raw)) {
+    return raw
+      .flatMap((r) => String(r).split(","))
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return String(raw)
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+const REFERENCE_SUPPORTED_VENDORS = new Set(["codex", "gemini"]);
+
+function supportsReference(vendor: string): boolean {
+  return REFERENCE_SUPPORTED_VENDORS.has(vendor);
 }
 
 function printAuthFailure(

--- a/cli/commands/image/generate.ts
+++ b/cli/commands/image/generate.ts
@@ -83,7 +83,10 @@ export async function runGenerate({
     return 4;
   }
 
-  if (references.length > 0) {
+  // For explicit vendor modes (all / <name>), reject early if any requested
+  // vendor lacks reference support. `auto` defers to the health filter below
+  // and silently drops unsupported vendors from the run set.
+  if (references.length > 0 && vendorFlag !== "auto") {
     const unsupported = requested.filter((p) => !supportsReference(p.name));
     if (unsupported.length > 0) {
       console.error(
@@ -128,7 +131,24 @@ export async function runGenerate({
     }
   }
 
-  const runProviders = healthy.map((h) => h.provider);
+  let runProviders = healthy.map((h) => h.provider);
+
+  // `auto` mode: drop reference-unsupported vendors from the healthy set so
+  // a pollinations-only-healthy environment doesn't block codex/gemini refs.
+  if (references.length > 0 && vendorFlag === "auto") {
+    const droppable = runProviders.filter((p) => !supportsReference(p.name));
+    runProviders = runProviders.filter((p) => supportsReference(p.name));
+    if (runProviders.length === 0) {
+      console.error(
+        color.red(
+          `--reference is not supported by any available vendor (${droppable
+            .map((p) => p.name)
+            .join(", ")}). Authenticate codex or gemini, or drop --reference.`,
+        ),
+      );
+      return 5;
+    }
+  }
   const runId = makeRunId();
   const compare = runProviders.length > 1;
   const outDir = resolveOutDir({

--- a/cli/commands/image/index.ts
+++ b/cli/commands/image/index.ts
@@ -36,6 +36,10 @@ export function registerImageCommand(program: Command): void {
       "Gemini fallback order, comma-separated (mcp,stream,api)",
     )
     .option("--timeout <seconds>", "Per-image timeout")
+    .option(
+      "-r, --reference <path...>",
+      "Reference image path(s); repeatable. Supported on codex and gemini vendors.",
+    )
     .option("-y, --yes", "Skip cost confirmation")
     .option(
       "--no-prompt-in-manifest",

--- a/cli/commands/image/index.ts
+++ b/cli/commands/image/index.ts
@@ -4,6 +4,19 @@ import { runDoctor } from "./doctor.js";
 import { runGenerate } from "./generate.js";
 import { runListVendors } from "./list-vendors.js";
 
+// Collector for the -r/--reference option. Commander invokes this once per
+// -r occurrence; by returning a new array each time we accumulate values
+// without the greedy variadic syntax (which would consume the positional
+// <prompt...>). The collector also splits comma-separated values, matching
+// the normalizer in generate.ts.
+function collectReference(value: string, previous: string[] = []): string[] {
+  const parts = value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return [...previous, ...parts];
+}
+
 export function registerImageCommand(program: Command): void {
   const image = program
     .command("image")
@@ -37,8 +50,10 @@ export function registerImageCommand(program: Command): void {
     )
     .option("--timeout <seconds>", "Per-image timeout")
     .option(
-      "-r, --reference <path...>",
-      "Reference image path(s); repeatable. Supported on codex and gemini vendors.",
+      "-r, --reference <path>",
+      "Reference image path; repeatable (-r a.png -r b.png) or comma-separated. Supported on codex and gemini vendors.",
+      collectReference,
+      [] as string[],
     )
     .option("-y, --yes", "Skip cost confirmation")
     .option(

--- a/cli/commands/image/manifest.test.ts
+++ b/cli/commands/image/manifest.test.ts
@@ -48,6 +48,40 @@ describe("writeManifest", () => {
     expect(parsed.runs[0].strategy_attempts[0].status).toBe("ok");
   });
 
+  it("records reference_images when provided", async () => {
+    const p = await writeManifest({
+      outDir: tmp,
+      runId: { timestamp: "20260424-143052", shortid: "ab12cd" },
+      prompt: "a red apple",
+      includePrompt: true,
+      options: { size: "1024x1024", quality: "auto", count: 1 },
+      costEstimate: 0.04,
+      runs,
+      startedAt: Date.now(),
+      referenceImages: ["/abs/path/one.png", "/abs/path/two.jpg"],
+    });
+    const parsed = JSON.parse(readFileSync(p, "utf8"));
+    expect(parsed.reference_images).toEqual([
+      "/abs/path/one.png",
+      "/abs/path/two.jpg",
+    ]);
+  });
+
+  it("omits reference_images field when none provided", async () => {
+    const p = await writeManifest({
+      outDir: tmp,
+      runId: { timestamp: "20260424-143052", shortid: "ab12cd" },
+      prompt: "no refs",
+      includePrompt: true,
+      options: { size: "1024x1024", quality: "auto", count: 1 },
+      costEstimate: 0,
+      runs,
+      startedAt: Date.now(),
+    });
+    const parsed = JSON.parse(readFileSync(p, "utf8"));
+    expect(parsed.reference_images).toBeUndefined();
+  });
+
   it("replaces prompt with prompt_sha256 when opted out", async () => {
     const p = await writeManifest({
       outDir: tmp,

--- a/cli/commands/image/manifest.ts
+++ b/cli/commands/image/manifest.ts
@@ -12,6 +12,7 @@ export interface WriteManifestArgs {
   costEstimate: number;
   runs: ManifestRun[];
   startedAt: number;
+  referenceImages?: string[];
 }
 
 export async function writeManifest(args: WriteManifestArgs): Promise<string> {
@@ -28,6 +29,9 @@ export async function writeManifest(args: WriteManifestArgs): Promise<string> {
     manifest.prompt_sha256 = createHash("sha256")
       .update(args.prompt)
       .digest("hex");
+  }
+  if (args.referenceImages && args.referenceImages.length > 0) {
+    manifest.reference_images = [...args.referenceImages];
   }
 
   const manifestPath = path.join(args.outDir, "manifest.json");

--- a/cli/commands/image/naming.test.ts
+++ b/cli/commands/image/naming.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildOutputFilename,
   formatTimestamp,
   makeRunId,
   renderPattern,
+  sanitizeModelForFilename,
   shortId,
 } from "./naming.js";
 
@@ -35,5 +37,103 @@ describe("naming", () => {
 
   it("leaves unknown vars in place", () => {
     expect(renderPattern("{foo}/{bar}", { foo: "x" })).toBe("x/{bar}");
+  });
+});
+
+describe("sanitizeModelForFilename", () => {
+  it("keeps safe characters unchanged", () => {
+    expect(sanitizeModelForFilename("gpt-image-2")).toBe("gpt-image-2");
+    expect(sanitizeModelForFilename("gemini-2.5-flash-image")).toBe(
+      "gemini-2.5-flash-image",
+    );
+    expect(sanitizeModelForFilename("flux")).toBe("flux");
+  });
+
+  it("strips path separators and collapses dot-runs", () => {
+    expect(sanitizeModelForFilename("../../evil")).toBe("_evil");
+    expect(sanitizeModelForFilename("/etc/passwd")).toBe("_etc_passwd");
+    expect(sanitizeModelForFilename("a/b\\c")).toBe("a_b_c");
+  });
+
+  it("collapses runs of replacement underscores", () => {
+    expect(sanitizeModelForFilename("a///b")).toBe("a_b");
+    expect(sanitizeModelForFilename(";rm -rf")).toBe("_rm_-rf");
+  });
+
+  it("never allows '..' in output", () => {
+    for (const evil of [
+      "..",
+      "...",
+      "....",
+      "a..b",
+      "a...b",
+      "../model/..",
+      ".a.b.",
+    ]) {
+      expect(sanitizeModelForFilename(evil)).not.toContain("..");
+    }
+  });
+
+  it("falls back to 'model' for empty or all-invalid input", () => {
+    expect(sanitizeModelForFilename("")).toBe("model");
+    expect(sanitizeModelForFilename("!@#$%^&*")).toBe("_");
+  });
+});
+
+describe("buildOutputFilename", () => {
+  it("single-image filename includes vendor, sanitized model, and runShortid", () => {
+    expect(
+      buildOutputFilename({
+        vendor: "codex",
+        model: "gpt-image-2",
+        runShortid: "ab12cd",
+        total: 1,
+        ext: "png",
+      }),
+    ).toBe("codex-gpt-image-2-ab12cd.png");
+  });
+
+  it("multi-image filename appends 1-based index", () => {
+    const name = buildOutputFilename({
+      vendor: "gemini",
+      model: "gemini-2.5-flash-image",
+      runShortid: "xy9ef0",
+      index: 0,
+      total: 3,
+      ext: "png",
+    });
+    expect(name).toBe("gemini-gemini-2.5-flash-image-xy9ef0-1.png");
+  });
+
+  it("sanitizes malicious model names", () => {
+    const name = buildOutputFilename({
+      vendor: "codex",
+      model: "../../../etc/passwd",
+      runShortid: "ab12cd",
+      total: 1,
+      ext: "png",
+    });
+    expect(name).not.toContain("..");
+    expect(name).not.toContain("/");
+    expect(name).not.toContain("\\");
+    expect(name).toMatch(/^codex-[\w.-]+-ab12cd\.png$/);
+  });
+
+  it("different runShortid produces different filenames for same model", () => {
+    const a = buildOutputFilename({
+      vendor: "codex",
+      model: "gpt-image-2",
+      runShortid: "aaa111",
+      total: 1,
+      ext: "png",
+    });
+    const b = buildOutputFilename({
+      vendor: "codex",
+      model: "gpt-image-2",
+      runShortid: "bbb222",
+      total: 1,
+      ext: "png",
+    });
+    expect(a).not.toBe(b);
   });
 });

--- a/cli/commands/image/naming.ts
+++ b/cli/commands/image/naming.ts
@@ -35,3 +35,31 @@ export function renderPattern(
     (_m, key: string) => vars[key] ?? `{${key}}`,
   );
 }
+
+// Sanitize a model name for safe use in filenames:
+// - strip path separators and any non-[alnum._-] characters
+// - collapse dot-runs (".." or more) to "_" so no traversal sequence survives
+// - collapse runs of replacement underscores
+export function sanitizeModelForFilename(model: string): string {
+  const cleaned = model
+    .replace(/[^a-zA-Z0-9._-]/g, "_")
+    .replace(/\.{2,}/g, "_")
+    .replace(/_+/g, "_");
+  return cleaned.length > 0 ? cleaned : "model";
+}
+
+export interface OutputNameArgs {
+  vendor: string;
+  model: string;
+  runShortid: string;
+  index?: number;
+  total: number;
+  ext: string;
+}
+
+export function buildOutputFilename(args: OutputNameArgs): string {
+  const safeModel = sanitizeModelForFilename(args.model);
+  const base = `${args.vendor}-${safeModel}-${args.runShortid}`;
+  const suffix = args.total > 1 ? `-${(args.index ?? 0) + 1}` : "";
+  return `${base}${suffix}.${args.ext}`;
+}

--- a/cli/commands/image/providers/codex.test.ts
+++ b/cli/commands/image/providers/codex.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { buildInstruction } from "./codex.js";
+
+function baseInput(): Parameters<typeof buildInstruction>[0] {
+  return {
+    prompt: "a red apple",
+    size: "1024x1024",
+    quality: "high",
+    n: 1,
+    model: "gpt-image-2",
+    outDir: "/tmp",
+    signal: new AbortController().signal,
+  };
+}
+
+describe("buildInstruction", () => {
+  it("does not mention references when none provided", () => {
+    const out = buildInstruction(baseInput());
+    expect(out).not.toContain("Reference image");
+    expect(out).toContain("a red apple");
+    expect(out).toContain("gpt-image-2");
+  });
+
+  it("adds a reference hint when referenceImages present", () => {
+    const out = buildInstruction({
+      ...baseInput(),
+      referenceImages: [
+        { path: "/tmp/a.png", mime: "image/png" },
+        { path: "/tmp/b.jpg", mime: "image/jpeg" },
+      ],
+    });
+    expect(out).toContain("Reference images are attached (2)");
+    expect(out).toContain(
+      "match their style, subject identity, or composition",
+    );
+  });
+
+  it("singular reference count also rendered correctly", () => {
+    const out = buildInstruction({
+      ...baseInput(),
+      referenceImages: [{ path: "/tmp/solo.png", mime: "image/png" }],
+    });
+    expect(out).toContain("Reference images are attached (1)");
+  });
+});

--- a/cli/commands/image/providers/codex.ts
+++ b/cli/commands/image/providers/codex.ts
@@ -4,6 +4,7 @@ import { copyFile, readdir, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { ImageConfig } from "../config.js";
+import { buildOutputFilename, shortId } from "../naming.js";
 import type {
   GenerateInput,
   GenerateResult,
@@ -67,10 +68,14 @@ export class CodexProvider implements VendorProvider {
     const existingBefore = await listGenerated(GENERATED_DIR);
     const instruction = buildInstruction({ ...input, model });
 
+    const imageArgs = (input.referenceImages ?? []).flatMap((r) => [
+      "-i",
+      r.path,
+    ]);
     const start = Date.now();
     const res = await runCapture(
       "codex",
-      ["exec", "--skip-git-repo-check", instruction],
+      ["exec", "--skip-git-repo-check", ...imageArgs, instruction],
       input.signal,
       (input.timeoutSec ?? 180) * 1000,
     );
@@ -91,13 +96,18 @@ export class CodexProvider implements VendorProvider {
     }
     const files = newFiles.slice(0, input.n);
     const results: GenerateResult[] = [];
+    const runShortid = input.runShortid ?? shortId();
     for (let i = 0; i < files.length; i += 1) {
       const src = files[i];
       if (!src) continue;
-      const dstName =
-        input.n === 1
-          ? `${this.name}-${model}.png`
-          : `${this.name}-${model}-${i + 1}.png`;
+      const dstName = buildOutputFilename({
+        vendor: this.name,
+        model,
+        runShortid,
+        index: i,
+        total: files.length,
+        ext: "png",
+      });
       const dst = path.join(input.outDir, dstName);
       await copyFile(src, dst);
       results.push({
@@ -124,13 +134,20 @@ export class CodexProvider implements VendorProvider {
   }
 }
 
-function buildInstruction(input: GenerateInput & { model: string }): string {
+export function buildInstruction(
+  input: GenerateInput & { model: string },
+): string {
   const sizeHint = input.size === "auto" ? "" : ` Size: ${input.size}.`;
   const qualityHint =
     input.quality === "auto" ? "" : ` Quality: ${input.quality}.`;
   const n = input.n === 1 ? "one image" : `${input.n} images`;
+  const refs = input.referenceImages ?? [];
+  const refHint =
+    refs.length > 0
+      ? `\nReference images are attached (${refs.length}). Use them as visual references — match their style, subject identity, or composition as described in the prompt.`
+      : "";
   return (
-    `Generate ${n} with the image_gen tool using model ${input.model}.${sizeHint}${qualityHint}\n` +
+    `Generate ${n} with the image_gen tool using model ${input.model}.${sizeHint}${qualityHint}${refHint}\n` +
     `Prompt: ${input.prompt}\n` +
     "Do not create, modify, or save any files in the working directory. Do not attempt to write text files, scripts, or notes. Only invoke the image_gen tool and return."
   );

--- a/cli/commands/image/providers/pollinations.ts
+++ b/cli/commands/image/providers/pollinations.ts
@@ -1,6 +1,7 @@
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { ImageConfig } from "../config.js";
+import { buildOutputFilename, shortId } from "../naming.js";
 import type {
   GenerateInput,
   GenerateResult,
@@ -73,6 +74,7 @@ export class PollinationsProvider implements VendorProvider {
     const timeoutMs = (input.timeoutSec ?? 180) * 1000;
 
     const results: GenerateResult[] = [];
+    const runShortid = input.runShortid ?? shortId();
     for (let i = 0; i < input.n; i += 1) {
       const started = Date.now();
       const bytes = await generateOne({
@@ -84,10 +86,14 @@ export class PollinationsProvider implements VendorProvider {
         timeoutMs,
       });
       const ext = bytes[0] === 0x89 ? "png" : "jpg";
-      const name =
-        input.n === 1
-          ? `${this.name}-${model}.${ext}`
-          : `${this.name}-${model}-${i + 1}.${ext}`;
+      const name = buildOutputFilename({
+        vendor: this.name,
+        model,
+        runShortid,
+        index: i,
+        total: input.n,
+        ext,
+      });
       const filePath = path.join(input.outDir, name);
       await writeFile(filePath, bytes);
       results.push({

--- a/cli/commands/image/reference-guard.test.ts
+++ b/cli/commands/image/reference-guard.test.ts
@@ -1,0 +1,115 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  MAX_REFERENCE_BYTES,
+  MAX_REFERENCE_COUNT,
+  validateReferenceImages,
+} from "./reference-guard.js";
+
+const PNG_HEADER = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+const JPEG_HEADER = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+const GIF_HEADER = Buffer.from("GIF89a");
+const WEBP_HEADER = Buffer.from([
+  0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+]);
+
+describe("validateReferenceImages", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "oma-ref-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function make(name: string, bytes: Buffer): string {
+    const p = path.join(tmp, name);
+    writeFileSync(p, bytes);
+    return p;
+  }
+
+  it("accepts PNG files and returns absolute path + mime + bytes", async () => {
+    const p = make("pic.png", Buffer.concat([PNG_HEADER, Buffer.alloc(100)]));
+    const out = await validateReferenceImages([p]);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.absolutePath).toBe(p);
+    expect(out[0]?.mime).toBe("image/png");
+    expect(out[0]?.bytes).toBe(PNG_HEADER.length + 100);
+  });
+
+  it("accepts JPEG/GIF/WebP via magic bytes", async () => {
+    const j = make("a.jpg", JPEG_HEADER);
+    const g = make("a.gif", GIF_HEADER);
+    const w = make("a.webp", WEBP_HEADER);
+    const out = await validateReferenceImages([j, g, w]);
+    expect(out.map((o) => o.mime)).toEqual([
+      "image/jpeg",
+      "image/gif",
+      "image/webp",
+    ]);
+  });
+
+  it("rejects unsupported format regardless of extension", async () => {
+    const p = make("fake.png", Buffer.from("not an image"));
+    await expect(validateReferenceImages([p])).rejects.toMatchObject({
+      kind: "invalid-input",
+      field: "reference",
+    });
+  });
+
+  it("rejects non-existent file with invalid-input", async () => {
+    await expect(
+      validateReferenceImages(["/nonexistent/path.png"]),
+    ).rejects.toMatchObject({ kind: "invalid-input", field: "reference" });
+  });
+
+  it("rejects directory passed as reference", async () => {
+    const dir = path.join(tmp, "subdir");
+    rmSync(dir, { recursive: true, force: true });
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(dir);
+    await expect(validateReferenceImages([dir])).rejects.toMatchObject({
+      kind: "invalid-input",
+      reason: expect.stringContaining("not a regular file"),
+    });
+  });
+
+  it("rejects files larger than MAX_REFERENCE_BYTES", async () => {
+    const p = make(
+      "big.png",
+      Buffer.concat([PNG_HEADER, Buffer.alloc(MAX_REFERENCE_BYTES + 1)]),
+    );
+    await expect(validateReferenceImages([p])).rejects.toMatchObject({
+      kind: "invalid-input",
+      reason: expect.stringContaining("limit"),
+    });
+  });
+
+  it("enforces MAX_REFERENCE_COUNT", async () => {
+    const refs = Array.from({ length: MAX_REFERENCE_COUNT + 1 }, (_, i) =>
+      make(`${i}.png`, PNG_HEADER),
+    );
+    await expect(validateReferenceImages(refs)).rejects.toMatchObject({
+      kind: "invalid-input",
+      reason: expect.stringContaining("too many"),
+    });
+  });
+
+  it("rejects duplicate paths (after resolve)", async () => {
+    const p = make("dup.png", PNG_HEADER);
+    await expect(validateReferenceImages([p, p])).rejects.toMatchObject({
+      kind: "invalid-input",
+      reason: expect.stringContaining("duplicate"),
+    });
+  });
+
+  it("resolves relative paths against cwd option", async () => {
+    make("rel.png", PNG_HEADER);
+    const out = await validateReferenceImages(["rel.png"], { cwd: tmp });
+    expect(out[0]?.absolutePath).toBe(path.join(tmp, "rel.png"));
+  });
+});

--- a/cli/commands/image/reference-guard.ts
+++ b/cli/commands/image/reference-guard.ts
@@ -1,0 +1,151 @@
+import { open, stat } from "node:fs/promises";
+import path from "node:path";
+import type { VendorError } from "./types.js";
+
+export const MAX_REFERENCE_BYTES = 5 * 1024 * 1024;
+export const MAX_REFERENCE_COUNT = 10;
+
+export type ReferenceMime =
+  | "image/png"
+  | "image/jpeg"
+  | "image/gif"
+  | "image/webp";
+
+export interface ValidatedReference {
+  absolutePath: string;
+  mime: ReferenceMime;
+  bytes: number;
+}
+
+export interface ValidateOptions {
+  cwd?: string;
+  maxBytes?: number;
+  maxCount?: number;
+}
+
+export async function validateReferenceImages(
+  paths: string[],
+  opts: ValidateOptions = {},
+): Promise<ValidatedReference[]> {
+  const cwd = opts.cwd ?? process.cwd();
+  const maxBytes = opts.maxBytes ?? MAX_REFERENCE_BYTES;
+  const maxCount = opts.maxCount ?? MAX_REFERENCE_COUNT;
+
+  if (paths.length > maxCount) {
+    throw {
+      kind: "invalid-input",
+      field: "reference",
+      reason: `too many references (${paths.length}); max=${maxCount}`,
+    } satisfies VendorError;
+  }
+
+  const seen = new Set<string>();
+  const out: ValidatedReference[] = [];
+  for (const raw of paths) {
+    const abs = path.resolve(cwd, raw);
+    if (seen.has(abs)) {
+      throw {
+        kind: "invalid-input",
+        field: "reference",
+        reason: `duplicate reference path: ${raw}`,
+      } satisfies VendorError;
+    }
+    seen.add(abs);
+
+    const st = await stat(abs).catch((err: NodeJS.ErrnoException) => {
+      throw {
+        kind: "invalid-input",
+        field: "reference",
+        reason: `cannot read reference: ${raw} (${err.code ?? "unknown error"})`,
+      } satisfies VendorError;
+    });
+    if (!st.isFile()) {
+      throw {
+        kind: "invalid-input",
+        field: "reference",
+        reason: `reference is not a regular file: ${raw}`,
+      } satisfies VendorError;
+    }
+    if (st.size > maxBytes) {
+      throw {
+        kind: "invalid-input",
+        field: "reference",
+        reason: `reference exceeds ${(maxBytes / (1024 * 1024)).toFixed(0)}MB limit: ${raw} (${st.size} bytes)`,
+      } satisfies VendorError;
+    }
+
+    const mime = await detectMime(abs, raw);
+    out.push({ absolutePath: abs, mime, bytes: st.size });
+  }
+  return out;
+}
+
+async function detectMime(
+  absolutePath: string,
+  displayName: string,
+): Promise<ReferenceMime> {
+  const fh = await open(absolutePath, "r");
+  try {
+    const buf = Buffer.alloc(12);
+    const { bytesRead } = await fh.read(buf, 0, 12, 0);
+    const slice = buf.subarray(0, bytesRead);
+    const mime = matchMagicBytes(slice);
+    if (!mime) {
+      throw {
+        kind: "invalid-input",
+        field: "reference",
+        reason: `unsupported format: ${displayName} (expected PNG, JPEG, GIF, or WebP)`,
+      } satisfies VendorError;
+    }
+    return mime;
+  } finally {
+    await fh.close();
+  }
+}
+
+function matchMagicBytes(buf: Buffer): ReferenceMime | null {
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (
+    buf.length >= 8 &&
+    buf[0] === 0x89 &&
+    buf[1] === 0x50 &&
+    buf[2] === 0x4e &&
+    buf[3] === 0x47
+  ) {
+    return "image/png";
+  }
+  // JPEG: FF D8 FF
+  if (
+    buf.length >= 3 &&
+    buf[0] === 0xff &&
+    buf[1] === 0xd8 &&
+    buf[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+  // GIF: 47 49 46 38 (GIF8)
+  if (
+    buf.length >= 4 &&
+    buf[0] === 0x47 &&
+    buf[1] === 0x49 &&
+    buf[2] === 0x46 &&
+    buf[3] === 0x38
+  ) {
+    return "image/gif";
+  }
+  // WebP: RIFF....WEBP
+  if (
+    buf.length >= 12 &&
+    buf[0] === 0x52 &&
+    buf[1] === 0x49 &&
+    buf[2] === 0x46 &&
+    buf[3] === 0x46 &&
+    buf[8] === 0x57 &&
+    buf[9] === 0x45 &&
+    buf[10] === 0x42 &&
+    buf[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  return null;
+}

--- a/cli/commands/image/strategies/gemini-api.test.ts
+++ b/cli/commands/image/strategies/gemini-api.test.ts
@@ -1,0 +1,52 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildReferenceParts } from "./gemini-api.js";
+
+describe("buildReferenceParts", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "oma-gemini-ref-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("encodes each file as base64 inlineData using the validated MIME", async () => {
+    const png = path.join(tmp, "a.png");
+    const jpg = path.join(tmp, "b.jpg");
+    writeFileSync(png, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    writeFileSync(jpg, Buffer.from([0xff, 0xd8, 0xff, 0xe0]));
+
+    const parts = await buildReferenceParts([
+      { path: png, mime: "image/png" },
+      { path: jpg, mime: "image/jpeg" },
+    ]);
+    expect(parts).toHaveLength(2);
+    expect(parts[0]?.inlineData?.mimeType).toBe("image/png");
+    expect(parts[0]?.inlineData?.data).toBe(
+      Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64"),
+    );
+    expect(parts[1]?.inlineData?.mimeType).toBe("image/jpeg");
+    expect(parts[1]?.inlineData?.data).toBe(
+      Buffer.from([0xff, 0xd8, 0xff, 0xe0]).toString("base64"),
+    );
+  });
+
+  it("uses the validated MIME rather than the file extension", async () => {
+    // Regression test for HIGH finding: buildReferenceParts must honor the
+    // magic-byte MIME detected by reference-guard, not re-derive from extension.
+    const mislabeled = path.join(tmp, "image.jpg"); // .jpg extension...
+    writeFileSync(mislabeled, Buffer.from([0x89, 0x50, 0x4e, 0x47])); // ...but PNG bytes
+    const parts = await buildReferenceParts([
+      { path: mislabeled, mime: "image/png" },
+    ]);
+    expect(parts[0]?.inlineData?.mimeType).toBe("image/png");
+  });
+
+  it("returns empty array for empty input", async () => {
+    const parts = await buildReferenceParts([]);
+    expect(parts).toEqual([]);
+  });
+});

--- a/cli/commands/image/strategies/gemini-api.ts
+++ b/cli/commands/image/strategies/gemini-api.ts
@@ -1,8 +1,10 @@
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { buildOutputFilename, shortId } from "../naming.js";
 import type {
   GenerateInput,
   GenerateResult,
+  ReferenceImage,
   StrategyAttempt,
   VendorError,
 } from "../types.js";
@@ -11,6 +13,24 @@ import type { GeminiStrategy, StrategyContext } from "./gemini-stream.js";
 interface InlinePart {
   inlineData?: { mimeType?: string; data?: string };
   inline_data?: { mime_type?: string; data?: string };
+}
+
+interface RequestPart {
+  text?: string;
+  inlineData?: { mimeType: string; data: string };
+}
+
+export async function buildReferenceParts(
+  refs: readonly ReferenceImage[],
+): Promise<RequestPart[]> {
+  const parts: RequestPart[] = [];
+  for (const r of refs) {
+    const buf = await readFile(r.path);
+    parts.push({
+      inlineData: { mimeType: r.mime, data: buf.toString("base64") },
+    });
+  }
+  return parts;
 }
 
 export const geminiApiStrategy: GeminiStrategy = {
@@ -33,12 +53,21 @@ export const geminiApiStrategy: GeminiStrategy = {
       } as VendorError;
     }
 
-    const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(ctx.model)}:generateContent?key=${apiKey}`;
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(ctx.model)}:generateContent?key=${encodeURIComponent(apiKey)}`;
     const results: GenerateResult[] = [];
     const attempts: StrategyAttempt[] = [{ strategy: "api", status: "ok" }];
 
+    const refs = input.referenceImages ?? [];
+    const referenceParts =
+      refs.length > 0 ? await buildReferenceParts(refs) : [];
+    const runShortid = input.runShortid ?? shortId();
+
     for (let i = 0; i < input.n; i += 1) {
       const started = Date.now();
+      const textPart: RequestPart = {
+        text: `${input.prompt}\n(image generation, size=${input.size}, quality=${input.quality})`,
+      };
+      const parts: RequestPart[] = [...referenceParts, textPart];
       const res = await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -46,11 +75,7 @@ export const geminiApiStrategy: GeminiStrategy = {
           contents: [
             {
               role: "user",
-              parts: [
-                {
-                  text: `${input.prompt}\n(image generation, size=${input.size}, quality=${input.quality})`,
-                },
-              ],
+              parts,
             },
           ],
         }),
@@ -81,10 +106,14 @@ export const geminiApiStrategy: GeminiStrategy = {
           cause: new Error("No inlineData image in response"),
         } as VendorError;
       }
-      const name =
-        input.n === 1
-          ? `${ctx.vendorName}-${ctx.model}.png`
-          : `${ctx.vendorName}-${ctx.model}-${i + 1}.png`;
+      const name = buildOutputFilename({
+        vendor: ctx.vendorName,
+        model: ctx.model,
+        runShortid,
+        index: i,
+        total: input.n,
+        ext: "png",
+      });
       const filePath = path.join(input.outDir, name);
       await writeFile(filePath, Buffer.from(raw, "base64"));
       results.push({

--- a/cli/commands/image/types.ts
+++ b/cli/commands/image/types.ts
@@ -10,6 +10,13 @@ export interface GenerateInput {
   outDir: string;
   signal: AbortSignal;
   timeoutSec?: number;
+  referenceImages?: ReferenceImage[];
+  runShortid?: string;
+}
+
+export interface ReferenceImage {
+  path: string;
+  mime: "image/png" | "image/jpeg" | "image/gif" | "image/webp";
 }
 
 export interface StrategyAttempt {
@@ -84,6 +91,7 @@ export interface Manifest {
   options: { size: string; quality: string; count: number };
   cost_estimate_usd: number;
   runs: ManifestRun[];
+  reference_images?: string[];
 }
 
 export function exitForError(kind: VendorError["kind"] | undefined): number {

--- a/docs/SUPPORTED_AGENTS.md
+++ b/docs/SUPPORTED_AGENTS.md
@@ -14,7 +14,7 @@ The installer can then project compatibility to other tool-specific directories 
 | Gemini CLI | `.gemini/agents/` + `.agents/skills/` | First-class | Native + Adapter | Agent definitions generated as Markdown from `.agents/agents/`; same-vendor tasks can dispatch natively |
 | OpenCode | `.agents/skills/` | First-class | Native-compatible | Shares the same project-level source |
 | Amp | `.agents/skills/` | First-class | Native-compatible | Shares the same project-level source |
-| Cursor | `.agents/skills/` | First-class | Native-compatible | Can consume the same project-level skill source |
+| Cursor | `.agents/skills/` (+ `.cursor/rules/*.mdc` via `oma export cursor`) | First-class | Native-compatible | Can consume the same project-level skill source; `oma export cursor` materializes rules into `.cursor/rules/` for editor-native consumption |
 | GitHub Copilot | `.github/skills/` | Supported | Optional symlink | Created when selected during install |
 
 ## Vendor Adaptation

--- a/web/docs/cli-interfaces/commands.md
+++ b/web/docs/cli-interfaces/commands.md
@@ -880,6 +880,7 @@ oma img <subcommand> ...
 | `--model <name>` | Vendor-specific model override | |
 | `--strategy <list>` | Gemini fallback order, comma-separated (`mcp,stream,api`) | |
 | `--timeout <seconds>` | Per-image timeout | vendor default |
+| `-r, --reference <path>` | Reference image(s); repeatable (`-r a.png -r b.png`) or comma-separated. Supported on `codex` and `gemini`; rejected on `pollinations`. Each ≤5MB PNG/JPEG/GIF/WebP (magic-byte validated), max 10. | |
 | `-y, --yes` | Skip cost confirmation | `false` |
 | `--no-prompt-in-manifest` | Store SHA256 of prompt instead of raw text | `false` |
 | `--dry-run` | Print plan and cost estimate; do not execute | `false` |
@@ -901,6 +902,13 @@ oma image generate "cat astronaut" --vendor all
 
 # Cost estimate without spending
 oma image generate "test prompt" --dry-run
+
+# Use a reference image to guide style / subject (codex or gemini)
+oma image generate "same otter in dramatic lighting" --vendor codex -r ~/Downloads/otter.jpeg
+
+# Multiple references (repeatable or comma-separated)
+oma image generate "blend these styles" --vendor gemini -r a.png -r b.png
+oma image generate "blend these styles" --vendor gemini -r a.png,b.png
 
 # Per-vendor doctor check
 oma image doctor --format json

--- a/web/docs/cli-interfaces/commands.md
+++ b/web/docs/cli-interfaces/commands.md
@@ -264,6 +264,37 @@ oma stats --json
 oma stats --reset
 ```
 
+### recap
+
+Recap AI tool conversation history across Claude, Codex, Gemini, Qwen, and Cursor sessions.
+
+```
+oma recap [--window <period>] [--date <date>] [--tool <tools>] [--top <n>] [--sort <metric>] [--mermaid] [--graph] [--json] [--output <format>]
+```
+
+**Options:**
+
+| Flag | Description | Default |
+|:-----|:-----------|:--------|
+| `--window <period>` | Time window: `1d`, `3d`, `7d`, `2w`, `30d` | `1d` |
+| `--date <date>` | Specific date (`YYYY-MM-DD`); takes precedence over `--window` | |
+| `--tool <tools>` | Comma-separated filter: `claude,codex,gemini,qwen,cursor` | all |
+| `--top <n>` | Show top N projects/topics | |
+| `--sort <metric>` | Sort by `count` or `duration` | `count` |
+| `--mermaid` | Output as Mermaid Gantt chart | |
+| `--graph` | Open interactive graph in the browser | |
+| `--json` / `--output <format>` | Machine-readable output | `text` |
+
+**Examples:**
+
+```bash
+oma recap                                     # Today (1d)
+oma recap --window 7d                         # Last week
+oma recap --date 2026-04-20 --tool claude,codex
+oma recap --window 7d --mermaid > week.mmd
+oma recap --window 30d --graph                # Interactive browser graph
+```
+
 ### retro
 
 Engineering retrospective with metrics and trends.
@@ -704,6 +735,175 @@ oma viz [--json] [--output <format>]
 ```bash
 oma visualize
 oma viz --json
+```
+
+### export
+
+Export skills for external IDEs that consume their own rules format (e.g. Cursor).
+
+```
+oma export <format> [-d <path>] [--json] [--output <format>]
+```
+
+**Arguments:**
+
+| Argument | Required | Description |
+|:---------|:---------|:-----------|
+| `format` | Yes | Target format. Currently supports: `cursor` |
+
+**Options:**
+
+| Flag | Short | Description | Default |
+|:-----|:------|:-----------|:--------|
+| `--dir <path>` | `-d` | Target directory to write the exported rules into. | Current working directory |
+| `--json` / `--output <format>` | | Machine-readable output | `text` |
+
+**Examples:**
+
+```bash
+# Export to ./.cursor/rules in the current project
+oma export cursor
+
+# Export to a sibling project's directory
+oma export cursor -d ../another-project
+```
+
+### search
+
+Mechanical search primitives — fetch, metadata, RSS, media, code, and trust scoring. Aliased as `oma s`. All subcommands output JSON to stdout (one object per line, or pretty-printed with `--pretty`).
+
+```
+oma search <subcommand> ...
+oma s <subcommand> ...
+```
+
+**Subcommands:**
+
+| Subcommand | Purpose |
+|:-----------|:--------|
+| `fetch <url>` | Fetch URL via auto-escalating strategy pipeline (api → probe → impersonate → browser → archive) |
+| `api <url>` | Fetch via matched platform API handler (Phase 0) |
+| `api:search <query>` | Fan-out keyword search across platforms that support it (`--platforms <list>`) |
+| `meta <url>` | Extract OGP / JSON-LD / Schema.org metadata |
+| `rss <url>` | Discover and parse RSS / Atom feed |
+| `rss:google <query>` | Build a Google News RSS URL for a query |
+| `media <url>` | Extract media metadata via `yt-dlp` (1858 sites) |
+| `archive <url>` | Fetch via AMP / archive.today / Wayback fallback |
+| `trust <domain>` | Resolve trust level / score for a domain |
+| `code <query>` | Search code via `gh` (GitHub) or `glab` (GitLab) |
+| `doctor` | Check dependencies (Chrome, `python3` + `curl_cffi`, `yt-dlp`, `gh`) |
+
+**Common options on URL/query subcommands:**
+
+| Flag | Description | Default |
+|:-----|:-----------|:--------|
+| `--timeout <seconds>` | Per-strategy timeout | `15` (`30` for `media`) |
+| `--locale <value>` | `Accept-Language` header | `en-US,en;q=0.9` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+**`fetch` extras:**
+
+| Flag | Description |
+|:-----|:-----------|
+| `--only <strategies>` | Comma-separated strategies to run (`api,probe,impersonate,browser,archive`) |
+| `--skip <strategies>` | Comma-separated strategies to skip |
+| `--include-archive` | Append archive strategy as a last fallback |
+
+**`media` extras:**
+
+| Flag | Description |
+|:-----|:-----------|
+| `--subs` | Write subtitles |
+| `--sub-lang <list>` | Subtitle languages, comma-separated (default: `en`) |
+| `--format <spec>` | yt-dlp format spec |
+
+**`code` extras:**
+
+| Flag | Description | Default |
+|:-----|:-----------|:--------|
+| `--host <github\|gitlab>` | Host | `github` |
+| `--language <lang>` | Language filter | |
+| `--repo <owner/repo>` | Scope to a repo | |
+| `--limit <n>` | Max results | `20` |
+
+**Exit codes:** `0` ok, `1` error, `2` blocked, `3` not-found, `4` invalid-input, `5` auth-required, `6` timeout.
+
+**Examples:**
+
+```bash
+# Auto-escalating fetch
+oma search fetch https://example.com/article --pretty
+
+# Force a single strategy
+oma search fetch https://example.com --only browser
+
+# Cross-platform keyword search via API handlers
+oma search api:search "RAG patterns" --platforms hackernews,reddit
+
+# Find a repo's trust score
+oma search trust github.com
+
+# Code search (defaults to GitHub)
+oma search code "useEffect cleanup" --language ts --limit 10
+
+# Verify your local dependencies
+oma search doctor
+```
+
+### image
+
+Multi-vendor AI image generation with authentication-aware parallel dispatch. Aliased as `oma img`.
+
+```
+oma image <subcommand> ...
+oma img <subcommand> ...
+```
+
+**Subcommands:**
+
+| Subcommand | Purpose |
+|:-----------|:--------|
+| `generate <prompt...>` | Generate images via `pollinations` (flux/zimage, free), `codex` (gpt-image-2 via ChatGPT OAuth), or `gemini` (needs API key + billing, disabled by default) |
+| `doctor` | Check authentication and install status per vendor |
+| `list-vendors` | List registered vendors and supported models |
+
+**`image generate` options:**
+
+| Flag | Description | Default |
+|:-----|:-----------|:--------|
+| `--vendor <name>` | `auto` \| `pollinations` \| `codex` \| `gemini` \| `all` | `auto` |
+| `--size <size>` | `1024x1024` \| `1024x1536` \| `1536x1024` \| `auto` | vendor default |
+| `--quality <level>` | `low` \| `medium` \| `high` \| `auto` | vendor default |
+| `-n, --count <n>` | Number of images (1..5) | `1` |
+| `--out <dir>` | Output directory | `.agents/results/images/{timestamp}/` |
+| `--allow-external-out` | Allow `--out` paths outside `$PWD` | `false` |
+| `--model <name>` | Vendor-specific model override | |
+| `--strategy <list>` | Gemini fallback order, comma-separated (`mcp,stream,api`) | |
+| `--timeout <seconds>` | Per-image timeout | vendor default |
+| `-y, --yes` | Skip cost confirmation | `false` |
+| `--no-prompt-in-manifest` | Store SHA256 of prompt instead of raw text | `false` |
+| `--dry-run` | Print plan and cost estimate; do not execute | `false` |
+| `--format <format>` | CLI output format: `text` \| `json` | `text` |
+
+Each run writes a `manifest.json` next to the generated images recording vendor, model, prompt (or hash), size, quality, and cost.
+
+**Examples:**
+
+```bash
+# Free, no-config generation
+oma image generate "minimalist sunrise over mountains"
+
+# Specific vendor + size + count, skip cost prompt
+oma image generate "logo concept" --vendor codex --size 1024x1024 -n 3 -y
+
+# All vendors in parallel for comparison
+oma image generate "cat astronaut" --vendor all
+
+# Cost estimate without spending
+oma image generate "test prompt" --dry-run
+
+# Per-vendor doctor check
+oma image doctor --format json
 ```
 
 ### star

--- a/web/docs/cli-interfaces/options.md
+++ b/web/docs/cli-interfaces/options.md
@@ -69,6 +69,10 @@ Set this environment variable to `json` to force JSON output on all commands tha
 | `verify` | Yes | Yes | Verification results per check |
 | `visualize` | Yes | Yes | Dependency graph as JSON |
 | `describe` | Always JSON | N/A | Always outputs JSON (introspection command) |
+| `recap` | Yes | Yes | Conversation history per tool/session |
+| `export` | Yes | Yes | Export status and target paths |
+| `image generate` / `image doctor` / `image list-vendors` | `--format json` | N/A | Use `--format json` instead of `--json` |
+| `search ...` | Always JSON | N/A | All `search` subcommands stream JSON; use `--pretty` for human reading |
 
 ---
 
@@ -230,6 +234,83 @@ workspace: ./api # optional
 - agent: frontend
 task: "Build user dashboard"
 ```
+
+### recap
+
+```
+oma recap [--window <period>] [--date <date>] [--tool <tools>] [--top <n>] [--sort <metric>] [--mermaid] [--graph] [--json] [--output <format>]
+```
+
+| Flag | Description | Default |
+|:-----|:-----------|:--------|
+| `--window <period>` | Time window: `1d`, `3d`, `7d`, `2w`, `30d`. Ignored when `--date` is set. | `1d` |
+| `--date <date>` | Specific date (`YYYY-MM-DD`). Takes precedence over `--window`. | |
+| `--tool <tools>` | Filter sessions by tool. Comma-separated: `claude`, `codex`, `gemini`, `qwen`, `cursor`. | all tools |
+| `--top <n>` | Show only top N projects/topics in the summary. | unlimited |
+| `--sort <metric>` | Sort sessions by `count` or `duration`. | `count` |
+| `--mermaid` | Output a Mermaid Gantt chart instead of the default summary. | `false` |
+| `--graph` | Open an interactive graph in the browser. Mutually exclusive with `--mermaid`. | `false` |
+
+### export
+
+```
+oma export <format> [-d <path>] [--json] [--output <format>]
+```
+
+| Flag | Short | Description | Default |
+|:-----|:------|:-----------|:--------|
+| `--dir <path>` | `-d` | Target directory to write the exported rules into. | `process.cwd()` |
+
+**Supported formats:** `cursor` (writes `.cursor/rules` files derived from the installed skills).
+
+### search
+
+```
+oma search <subcommand> [...]
+```
+
+The `search` group ships its own JSON output (no `--json` / `--output` flags). Use `--pretty` on URL/query subcommands to pretty-print results, and rely on subcommand-specific options below:
+
+| Subcommand | Notable Options |
+|:-----------|:---------------|
+| `fetch <url>` | `--only`, `--skip`, `--include-archive`, `--timeout`, `--locale`, `--pretty` |
+| `api <url>` / `meta <url>` / `rss <url>` / `archive <url>` | `--timeout`, `--locale`, `--pretty` |
+| `api:search <query>` | `--platforms <list>`, `--timeout`, `--locale`, `--pretty` |
+| `rss:google <query>` | `--locale` (default `en-US`) |
+| `media <url>` | `--subs`, `--sub-lang <list>` (default `en`), `--format <spec>`, `--timeout` (default `30`), `--pretty` |
+| `code <query>` | `--host <github\|gitlab>` (default `github`), `--language`, `--repo`, `--limit` (default `20`), `--pretty` |
+| `trust <domain>` | `--pretty` |
+| `doctor` | none — runs binary checks for Chrome / `python3 curl_cffi` / `yt-dlp` / `gh` |
+
+**Exit codes:** `0` ok, `1` error, `2` blocked, `3` not-found, `4` invalid-input, `5` auth-required, `6` timeout. Use these in scripts to differentiate transient blockers from invalid inputs.
+
+### image
+
+```
+oma image <subcommand> [...]
+```
+
+Output format is controlled per subcommand via `--format <text|json>` (not the shared `--json` flag).
+
+`image generate` accepts:
+
+| Flag | Short | Description | Default |
+|:-----|:------|:-----------|:--------|
+| `--vendor <name>` | | `auto` \| `pollinations` \| `codex` \| `gemini` \| `all`. `auto` resolves from `image-config.yaml` and available auth. | `auto` |
+| `--size <size>` | | `1024x1024` \| `1024x1536` \| `1536x1024` \| `auto`. | vendor default |
+| `--quality <level>` | | `low` \| `medium` \| `high` \| `auto`. | vendor default |
+| `--count <n>` | `-n` | Number of images, 1..5. | `1` |
+| `--out <dir>` | | Output directory. Must be inside `$PWD` unless `--allow-external-out` is set. | `.agents/results/images/{timestamp}/` |
+| `--allow-external-out` | | Allow `--out` paths outside `$PWD`. | `false` |
+| `--model <name>` | | Vendor-specific model override (e.g. `gpt-image-2`, `flux`, `imagen-4`). | vendor default |
+| `--strategy <list>` | | Gemini fallback order, comma-separated of `mcp`, `stream`, `api`. | vendor default |
+| `--timeout <seconds>` | | Per-image timeout. | vendor default |
+| `--yes` | `-y` | Skip the cost confirmation prompt. | `false` |
+| `--no-prompt-in-manifest` | | Store SHA256 of the prompt instead of the raw text in `manifest.json`. | `false` |
+| `--dry-run` | | Print plan and cost estimate; do not execute. | `false` |
+| `--format <format>` | | `text` \| `json`. | `text` |
+
+`image doctor` and `image list-vendors` only accept `--format <text|json>`.
 
 ### memory:init
 

--- a/web/docs/cli-interfaces/options.md
+++ b/web/docs/cli-interfaces/options.md
@@ -305,6 +305,7 @@ Output format is controlled per subcommand via `--format <text|json>` (not the s
 | `--model <name>` | | Vendor-specific model override (e.g. `gpt-image-2`, `flux`, `imagen-4`). | vendor default |
 | `--strategy <list>` | | Gemini fallback order, comma-separated of `mcp`, `stream`, `api`. | vendor default |
 | `--timeout <seconds>` | | Per-image timeout. | vendor default |
+| `--reference <path>` | `-r` | Reference image for style/subject transfer. Repeatable (`-r a.png -r b.png`) or comma-separated. Validated for size (≤5MB), format (PNG/JPEG/GIF/WebP via magic bytes), and count (≤10). Supported on `codex` (passes `-i` to `codex exec`) and `gemini` (inlines base64 `inlineData`). Rejected with exit 4 on `pollinations`. | |
 | `--yes` | `-y` | Skip the cost confirmation prompt. | `false` |
 | `--no-prompt-in-manifest` | | Store SHA256 of the prompt instead of the raw text in `manifest.json`. | `false` |
 | `--dry-run` | | Print plan and cost estimate; do not execute. | `false` |

--- a/web/docs/core-concepts/agents.md
+++ b/web/docs/core-concepts/agents.md
@@ -1,6 +1,6 @@
 ---
 title: Agents
-description: Complete reference for all 21 oh-my-agent agents — their domains, tech stacks, resource files, capabilities, charter preflight protocol, two-layer skill loading, scoped execution rules, quality gates, workspace strategy, orchestration flow, and runtime memory.
+description: Complete reference for all 22 oh-my-agent agents — their domains, tech stacks, resource files, capabilities, charter preflight protocol, two-layer skill loading, scoped execution rules, quality gates, workspace strategy, orchestration flow, and runtime memory.
 ---
 
 # Agents

--- a/web/docs/getting-started/installation.md
+++ b/web/docs/getting-started/installation.md
@@ -125,16 +125,22 @@ oma dashboard:web # Web dashboard at http://localhost:9847
 oma agent:spawn # Spawn agents from terminal
 oma agent:parallel # Parallel agent execution
 oma agent:status # Check agent status
+oma agent:review # Code review via external CLI (codex/claude/gemini/qwen)
 oma stats # Session statistics
-oma retro # Retrospective analysis
+oma retro # Engineering retrospective (commits, hotspots, trends)
+oma recap # Conversation history recap across AI tools
 oma cleanup # Clean up session artifacts
+oma link # Regenerate vendor-native files from `.agents/` SSOT
 oma update # Update oh-my-agent
-oma verify # Verify agent output
-oma visualize # Dependency visualization
-oma describe # Describe project structure
-oma bridge # SSE-to-stdio bridge for Antigravity
-oma memory:init # Initialize memory provider
-oma auth:status # Check CLI auth status
+oma verify # Verify agent output (build/test/scope/secrets)
+oma visualize # Dependency visualization (alias: `oma viz`)
+oma describe # Introspect CLI commands as JSON
+oma bridge # MCP stdio ↔ Streamable HTTP bridge
+oma memory:init # Initialize Serena memory schema
+oma auth:status # Check CLI auth status (gh/gemini/claude/codex/qwen)
+oma search # Mechanical search primitives (alias: `oma s`)
+oma image # Multi-vendor AI image generation (alias: `oma img`)
+oma export # Export skills for external IDEs (e.g. cursor)
 oma star # Star the repository
 ```
 


### PR DESCRIPTION
## Summary

Adds `-r/--reference <path...>` to `oma image generate` so users in Claude Code / Antigravity can forward locally-attached images as style/subject references to `codex` (gpt-image-2) and `gemini` (2.5-flash-image). Pollinations is deferred to PR #2 (requires URL hosting).

Also hardens filename generation repo-wide: output filenames now include a per-run shortid (prevents clobbering when `--out <fixed-dir>` is reused) and the model component is sanitized against path-traversal injection.

## What's new

- **CLI**: `-r, --reference <path...>` (repeatable, comma-separated supported)
- **Validation** (`reference-guard.ts`): exists · is file · ≤ 5MB · ≤ 10 total · magic-byte MIME check (PNG/JPEG/GIF/WebP) · duplicate path rejection
- **Codex**: appends `-i <path>` per ref to `codex exec`, adds an instruction hint
- **Gemini**: reads → base64 → `{inlineData: {mimeType, data}}` parts prepended to text prompt. Uses the magic-byte-validated MIME (not file extension) so mislabeled files are still sent correctly
- **Manifest**: records `reference_images[]` (absolute paths)
- **Cost**: Gemini gets a conservative `+$0.01` per reference per image surcharge
- **Filenames**: `{vendor}-{sanitize(model)}-{runShortid}[-{i}].{ext}` — unique per run, no path traversal

## Host-specific paths (documented)

| Host CLI | Attachment → path |
|---|---|
| **Claude Code** | `~/.claude/image-cache/<session-uuid>/N.png` (surfaced in system messages; cleared on session end) |
| **Antigravity** | Workspace upload dir |
| **Codex CLI as host** | Attachments not exposed to filesystem — user must pass explicit path |

## Out of scope (→ PR #2)

- Pollinations reference support (needs data-URL or CDN upload)
- Auto-discovery of host-specific cache paths from agent prompts

## Files

- **Modified (15)**: types, index, generate, manifest, cost, naming, codex, gemini-api, pollinations, cost.test, manifest.test, naming.test, SKILL.md, execution-protocol.md, vendor-matrix.md
- **Created (4)**: reference-guard.ts, reference-guard.test.ts, codex.test.ts, gemini-api.test.ts

## Test plan

- [x] \`bun run --cwd cli test\` — 1037 pass / 0 fail (baseline was 1009/1010; +28 new tests, pre-existing hud.test flake also resolved)
- [x] \`bun run --cwd cli lint\` — clean
- [x] \`bun run --cwd cli build\` — succeeds
- [x] E2E smoke tests:
  - \`-r /nonexistent.png\` → exit 4 "cannot read reference"
  - \`-r fake.png\` (bad magic bytes) → exit 4 "unsupported format"
  - \`--vendor pollinations -r <valid.png>\` → exit 4 with hint
  - \`--dry-run --vendor codex -r <valid.png>\` → plan JSON shows \`referenceImages\`
- [x] Sanitize fuzzing: no \`..\` or \`/\` survives in output filename for any input
- [ ] Manual smoke test with real Codex call (requires ChatGPT subscription)
- [ ] Manual smoke test with Gemini (requires GEMINI_API_KEY + billing)

## Review process

Ran \`/ultrawork\` (5-phase gate loop) followed by \`/review\` (qa-reviewer subagent). Review found 1 HIGH (MIME divergence between guard and API boundary) + 3 MEDIUM + 5 LOW — all HIGH/MEDIUM addressed in this PR; LOW items either fixed or documented as out-of-scope/pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)