### PR TITLE
docs(image): mandate auto-forward of attached references

### DIFF
--- a/.agents/skills/oma-image/SKILL.md
+++ b/.agents/skills/oma-image/SKILL.md
@@ -113,6 +113,24 @@ Supported vendors:
 - **Antigravity**: workspace upload directory (exact path shown in IDE)
 - **Codex CLI as host**: user must pass the filesystem path explicitly; in-conversation attachments are not forwarded
 
+### Agent Behavior: Auto-forward Attached References (MANDATORY)
+
+When ALL of the following are true, the calling agent MUST pass the attached image via `--reference <path>` automatically. Never describe the image in prose as a workaround.
+
+1. The user asks to generate or edit an image (referencing the attached one by phrases like "이거", "this image", "same style as this", "이 수달", etc.).
+2. A host-surfaced attached image is visible to the agent — e.g. a Claude Code system message with `[Image: source: <path>]`, or an Antigravity workspace upload path, or an explicit filesystem path in the user's message.
+3. The selected vendor supports references (`codex` or `gemini`).
+
+**Required action**: invoke `oma image generate --reference <absolute-path> --vendor <codex|gemini> "<prompt>"`. If the user didn't specify a vendor, default to `codex` (CLI-first, widest availability). Do NOT:
+
+- Fall back to prose description ("I'll describe the otter's appearance...").
+- Ask the user to re-type or re-attach the path.
+- Claim the CLI doesn't support references without first running `oma image generate --help` to verify.
+
+**If the local CLI is outdated** (`--reference` is missing from `--help`): tell the user to run `oma update` once, then retry. Do not silently degrade to prose.
+
+**If the reference path is from Claude Code's `image-cache`**: note to the user that the path is session-scoped and suggest copying the file to a durable location if they want to reuse it later. Still proceed with the generation.
+
 ### Shared Infrastructure (from other skills)
 
 Other skills call `oma image generate --format json` and parse the JSON manifest from stdout.

--- a/.agents/skills/oma-image/resources/execution-protocol.md
+++ b/.agents/skills/oma-image/resources/execution-protocol.md
@@ -27,6 +27,10 @@ When `--reference <path...>` is supplied:
    - `gemini` api strategy reads each file, base64-encodes it, and prepends `{ inlineData: { mimeType, data } }` parts before the text prompt.
 4. Record reference paths in `manifest.json` under `reference_images` (top-level array of absolute paths).
 
+### Auto-forward attached images (MANDATORY)
+
+If the user asks to generate/edit an image AND a host-attached image is visible to the agent (e.g. `[Image: source: <path>]` in a Claude Code system message, Antigravity workspace upload, or explicit user-provided path), the agent MUST pass it via `--reference <path>`. Do not fall back to describing the image in prose. Do not ask the user to re-type the path. If `oma image generate --help` shows no `--reference` flag, instruct the user to run `oma update` and retry — do not silently degrade.
+
 ### Host-Specific Reference Paths
 
 Agents invoking `oma image generate --reference` should surface the following host-specific locations to the user:


### PR DESCRIPTION
## Summary

PR #281 added \`-r/--reference\` but the skill docs only described WHERE to find attached image paths in each host (Claude Code cache, Antigravity workspace) — not that agents MUST use them. A downstream agent hit this gap and degraded to prose description instead of invoking the flag.

This PR closes that loop with a MANDATORY agent-behavior section.

## Changes

- \`.agents/skills/oma-image/SKILL.md\` — new "Agent Behavior: Auto-forward Attached References (MANDATORY)" section listing:
  - 3 trigger conditions (user requests gen/edit + attached image visible + ref-supporting vendor)
  - Required action (\`--reference <path>\` auto, default vendor codex)
  - 3 anti-patterns (prose fallback, re-asking path, assuming CLI lacks support)
  - Outdated-CLI handling (\`oma update\` + retry, never silent degrade)
  - Session-scoped path note for Claude Code cache
- \`.agents/skills/oma-image/resources/execution-protocol.md\` — mirror mandate in Step 0.5 so protocol-consulting agents get the same rule.

## Motivation

Regression caught in real usage: an agent running on an outdated CLI (v5.19.0, pre-#281) responded "CLI 현재 버전에 레퍼런스 이미지 플래그가 아직 노출되지 않아, 수달 외형을 프롬프트로 상세히 묘사해서 생성하겠습니다." instead of either using the flag or telling the user to update. That silent degradation is worse than an error.

## Test plan

- [x] \`bun run --cwd cli test\` — 1037 pass
- [x] \`bun run --cwd cli lint\` — clean
- [x] \`bun run --cwd cli build\` — succeeds
- [ ] Manual: future agent sessions should invoke \`-r\` automatically when an image is attached (verification only possible post-merge + downstream agent update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)