### PR TITLE
feat(install): add Hermes Agent skill export with HOME consent gate

### DIFF
--- a/cli/commands/install/install-home-policy.test.ts
+++ b/cli/commands/install/install-home-policy.test.ts
@@ -48,6 +48,11 @@ const skillsState = vi.hoisted(() => ({
   PRESETS: { custom: [] },
   INSTALLED_SKILLS_DIR: ".agents/skills",
   REPO: "first-fluke/oh-my-agent",
+  CLI_SKILLS_DIR: {
+    claude: { base: "project", path: ".claude/skills" },
+    copilot: { base: "project", path: ".github/skills" },
+    hermes: { base: "home", path: ".hermes/skills/oma" },
+  },
   getAllSkills: vi.fn(() => [
     { name: "oma-frontend", desc: "Frontend skill" },
     { name: "oma-pm", desc: "PM skill" },
@@ -61,6 +66,13 @@ const skillsState = vi.hoisted(() => ({
   installVendorAdaptations: vi.fn(),
   createCliSymlinks: vi.fn(() => ({ created: [], skipped: [] })),
   ensureCursorMcpSymlink: vi.fn(),
+  vendorRequiresHomeConsent: vi.fn((cli: string) => cli === "hermes"),
+  getVendorDisplayPath: vi.fn((cli: string) =>
+    cli === "hermes" ? "~/.hermes/skills/oma" : `.${cli}/skills`,
+  ),
+  isHookVendor: vi.fn((v: string) =>
+    ["claude", "codex", "cursor", "gemini", "qwen"].includes(v),
+  ),
   writeVendorsToConfig: vi.fn(),
 }));
 
@@ -119,7 +131,7 @@ vi.mock("../../io/serena.js", () => ({
 
 import { install } from "../install/install.js";
 
-describe("install home safety", () => {
+describe("install home policy", () => {
   const originalHome = process.env.HOME;
 
   beforeEach(() => {
@@ -127,12 +139,16 @@ describe("install home safety", () => {
 
     process.env.HOME = "/tmp/test-home";
 
+    // 3 select prompts: language, modelPreset, projectType
     promptState.select
       .mockResolvedValueOnce("en")
+      .mockResolvedValueOnce("claude-only")
       .mockResolvedValueOnce("custom");
+    // 2 multiselect prompts: skills, vendors
     promptState.multiselect
       .mockResolvedValueOnce(["oma-frontend"])
       .mockResolvedValueOnce(["gemini"]);
+    // Default: any consent prompt receives "false"
     promptState.confirm.mockResolvedValue(false);
 
     fsState.existsSync.mockImplementation((path: string) =>
@@ -147,7 +163,9 @@ describe("install home safety", () => {
     vi.restoreAllMocks();
   });
 
-  it("does not write to HOME-level vendor settings", async () => {
+  // --- Baseline invariant: non-hermes vendors never write HOME ---
+
+  it("does not write to HOME-level vendor settings (non-hermes)", async () => {
     await install();
 
     const writes = (
@@ -168,5 +186,74 @@ describe("install home safety", () => {
     expect(execCalls.some((cmd) => cmd.includes("git config --global"))).toBe(
       false,
     );
+  });
+
+  // --- Hermes consent gate: explicit opt-in required ---
+
+  it("does NOT add hermes to selectedClis when consent declined", async () => {
+    promptState.multiselect.mockReset();
+    promptState.multiselect
+      .mockResolvedValueOnce(["oma-frontend"])
+      .mockResolvedValueOnce(["hermes"]);
+    promptState.confirm.mockResolvedValue(false); // consent denied
+
+    await install();
+
+    const symlinkCalls = skillsState.createCliSymlinks.mock.calls;
+    expect(symlinkCalls.length).toBeGreaterThan(0);
+    // hermes must not be in the cliTools array passed to createCliSymlinks
+    for (const call of symlinkCalls) {
+      const cliTools = call[1] as string[];
+      expect(cliTools).not.toContain("hermes");
+    }
+  });
+
+  it("adds hermes to selectedClis when consent granted", async () => {
+    promptState.multiselect.mockReset();
+    promptState.multiselect
+      .mockResolvedValueOnce(["oma-frontend"])
+      .mockResolvedValueOnce(["hermes"]);
+    promptState.confirm.mockResolvedValue(true); // consent granted
+
+    await install();
+
+    const symlinkCalls = skillsState.createCliSymlinks.mock.calls;
+    const allCliTools = symlinkCalls.flatMap((c) => c[1] as string[]);
+    expect(allCliTools).toContain("hermes");
+  });
+
+  it("never passes hermes to installVendorAdaptations (no hook bridge)", async () => {
+    promptState.multiselect.mockReset();
+    promptState.multiselect
+      .mockResolvedValueOnce(["oma-frontend"])
+      .mockResolvedValueOnce(["claude", "hermes"]);
+    promptState.confirm.mockResolvedValue(true); // hermes consent granted
+
+    await install();
+
+    const adaptCalls = skillsState.installVendorAdaptations.mock.calls;
+    for (const call of adaptCalls) {
+      const hookVendors = call[2] as string[];
+      expect(hookVendors).not.toContain("hermes");
+      expect(hookVendors).not.toContain("copilot");
+    }
+  });
+
+  it("isolates HOME write — gemini selected does NOT trigger gemini HOME write", async () => {
+    promptState.multiselect.mockReset();
+    promptState.multiselect
+      .mockResolvedValueOnce(["oma-frontend"])
+      .mockResolvedValueOnce(["gemini", "hermes"]);
+    promptState.confirm.mockResolvedValue(true); // hermes consent granted
+
+    await install();
+
+    const writes = (
+      fs.writeFileSync as ReturnType<typeof vi.fn>
+    ).mock.calls.map((call: unknown[]) => String(call[0]));
+    // Gemini settings remain project-local — never HOME
+    expect(
+      writes.some((path) => path.startsWith("/tmp/test-home/.gemini/")),
+    ).toBe(false);
   });
 });

--- a/cli/commands/install/install.ts
+++ b/cli/commands/install/install.ts
@@ -30,9 +30,11 @@ import {
   mergeRulesIndexForVendor,
 } from "../../platform/rules.js";
 import {
+  CLI_SKILLS_DIR,
   createCliSymlinks,
   ensureCursorMcpSymlink,
   getAllSkills,
+  getVendorDisplayPath,
   INSTALLED_SKILLS_DIR,
   installCodexWorkflowSkills,
   installConfigs,
@@ -41,11 +43,14 @@ import {
   installSkill,
   installVendorAdaptations,
   installWorkflows,
+  isHookVendor,
   PRESETS,
   REPO,
+  type SkillTargetSpec,
+  vendorRequiresHomeConsent,
   writeVendorsToConfig,
 } from "../../platform/skills-installer.js";
-import type { CliTool, CliVendor, VendorType } from "../../types/index.js";
+import type { CliTool, CliVendor } from "../../types/index.js";
 import {
   applyRecommendedSettings,
   needsSettingsUpdate,
@@ -373,7 +378,12 @@ export async function install(_options: InstallOptions = {}): Promise<void> {
     }
   }
 
-  // CLI tools selection — default All, opt-out pattern
+  // CLI tools selection — default All for project-base vendors,
+  // opt-in only for HOME-base vendors (e.g., hermes).
+  // Auto-exclude HOME-write vendors on Windows / CI where symlink and
+  // HOME semantics are unreliable.
+  const allowHomeWriteVendors = process.platform !== "win32" && !process.env.CI;
+
   const vendorOptions: { value: CliVendor; label: string; hint: string }[] = [
     {
       value: "claude",
@@ -388,13 +398,30 @@ export async function install(_options: InstallOptions = {}): Promise<void> {
       hint: ".cursor/rules/ export + prompt hooks",
     },
     { value: "gemini", label: "Gemini CLI", hint: "hooks + Serena MCP" },
+    ...(allowHomeWriteVendors
+      ? [
+          {
+            value: "hermes" as const,
+            label: "Hermes Agent",
+            hint: "skills only — workflows N/A, HOME-shared (no per-project isolation)",
+          },
+        ]
+      : []),
     { value: "qwen", label: "Qwen Code", hint: "hooks + settings" },
   ];
 
   const selectedVendors = await p.multiselect({
     message: "CLI tools to configure:",
     options: vendorOptions,
-    initialValues: vendorOptions.map((v) => v.value),
+    // HOME-write vendors (hermes) are opt-in only — default off.
+    initialValues: vendorOptions
+      .filter((opt) => {
+        const spec = (CLI_SKILLS_DIR as Record<string, SkillTargetSpec>)[
+          opt.value
+        ];
+        return !spec || spec.base !== "home";
+      })
+      .map((v) => v.value),
     required: true,
   });
 
@@ -404,10 +431,34 @@ export async function install(_options: InstallOptions = {}): Promise<void> {
   }
 
   const vendors = selectedVendors as CliVendor[];
-  const hookVendors = vendors.filter((v): v is VendorType => v !== "copilot");
+  const hookVendors = vendors.filter(isHookVendor);
+
+  // Build selectedClis from CLI_SKILLS_DIR (data-driven). Vendors with
+  // base: "home" require explicit consent; other vendors are added directly.
+  const cliToolKeys = Object.keys(CLI_SKILLS_DIR) as CliTool[];
+  const requestedClis = vendors.filter((v): v is CliTool =>
+    (cliToolKeys as string[]).includes(v),
+  );
+
   const selectedClis: CliTool[] = [];
-  if (vendors.includes("claude")) selectedClis.push("claude");
-  if (vendors.includes("copilot")) selectedClis.push("copilot");
+  for (const cli of requestedClis) {
+    if (vendorRequiresHomeConsent(cli)) {
+      const consent = await p.confirm({
+        message: `${cli} export writes to HOME (${pc.cyan(getVendorDisplayPath(cli))}). Proceed?`,
+        initialValue: false,
+      });
+      if (p.isCancel(consent)) {
+        cleanup();
+        p.cancel("Cancelled.");
+        process.exit(0);
+      }
+      if (!consent) {
+        p.log.info(pc.dim(`Skipped ${cli} export.`));
+        continue;
+      }
+    }
+    selectedClis.push(cli);
+  }
 
   spinner.start("Installing skills...");
 

--- a/cli/commands/link/link.ts
+++ b/cli/commands/link/link.ts
@@ -12,9 +12,11 @@ import {
   getInstalledSkillNames,
   installCodexWorkflowSkills,
   installVendorAdaptations,
+  isHookVendor,
   readVendorsFromConfig,
+  vendorRequiresHomeConsent,
 } from "../../platform/skills-installer.js";
-import type { CliVendor, VendorType } from "../../types/index.js";
+import type { CliVendor } from "../../types/index.js";
 import {
   applyRecommendedCodexSettings,
   needsCodexSettingsUpdate,
@@ -55,9 +57,7 @@ export function link(vendorFilter?: string[]): void {
     configuredVendors = readVendorsFromConfig(cwd);
   }
 
-  const hookVendors = configuredVendors.filter(
-    (v): v is VendorType => v !== "copilot",
-  );
+  const hookVendors = configuredVendors.filter(isHookVendor);
 
   if (hookVendors.length === 0) {
     console.log(`${pc.yellow("⚠")} No vendors to link.`);
@@ -142,11 +142,16 @@ export function link(vendorFilter?: string[]): void {
     }
   }
 
-  // 5. Refresh CLI skill symlinks
+  // 5. Refresh CLI skill symlinks. HOME-write vendors only proceed if
+  // already in oma-config (consent recorded by `oma install`).
   const cliTools = detectExistingCliSymlinkDirs(cwd);
   if (cliTools.length > 0) {
     const skillNames = getInstalledSkillNames(cwd);
-    createCliSymlinks(cwd, cliTools, skillNames);
+    const recordedVendors = readVendorsFromConfig(cwd);
+    const safeCliTools = cliTools.filter(
+      (cli) => !vendorRequiresHomeConsent(cli) || recordedVendors.includes(cli),
+    );
+    createCliSymlinks(cwd, safeCliTools, skillNames);
   }
 
   // Summary

--- a/cli/commands/update/update-cursor.test.ts
+++ b/cli/commands/update/update-cursor.test.ts
@@ -44,6 +44,10 @@ vi.mock("../../platform/skills-installer.js", () => ({
   createCliSymlinks: vi.fn(() => ({ created: [], skipped: [] })),
   ensureCursorMcpSymlink: vi.fn(),
   readVendorsFromConfig: vi.fn(() => configuredVendorsForTest),
+  isHookVendor: vi.fn((v: string) =>
+    ["claude", "codex", "cursor", "gemini", "qwen"].includes(v),
+  ),
+  vendorRequiresHomeConsent: vi.fn((cli: string) => cli === "hermes"),
 }));
 
 import * as manifest from "../../platform/manifest.js";

--- a/cli/commands/update/update.ts
+++ b/cli/commands/update/update.ts
@@ -40,10 +40,11 @@ import {
   getInstalledSkillNames,
   installCodexWorkflowSkills,
   installVendorAdaptations,
+  isHookVendor,
   REPO,
   readVendorsFromConfig,
+  vendorRequiresHomeConsent,
 } from "../../platform/skills-installer.js";
-import type { VendorType } from "../../types/index.js";
 import { isAutoUpdateCliEnabled } from "../../utils/config.js";
 import {
   applyRecommendedSettings,
@@ -305,9 +306,7 @@ export async function update(force = false, ci = false): Promise<void> {
 
       // Update vendor adaptations for configured vendors (from oma-config.yaml)
       const configuredVendors = readVendorsFromConfig(cwd);
-      const hookVendors = configuredVendors.filter(
-        (v): v is VendorType => v !== "copilot",
-      );
+      const hookVendors = configuredVendors.filter(isHookVendor);
       if (configuredVendors.includes("codex")) {
         installCodexWorkflowSkills(repoDir, cwd);
       }
@@ -442,7 +441,15 @@ export async function update(force = false, ci = false): Promise<void> {
       if (cliTools.length > 0) {
         const skillNames = getInstalledSkillNames(cwd);
         if (skillNames.length > 0) {
-          const { created } = createCliSymlinks(cwd, cliTools, skillNames);
+          // Gate HOME-write vendors on the recorded consent (oma-config
+          // vendors list). update never re-prompts; missing record means
+          // the user never consented, so we silently skip.
+          const recordedVendors = readVendorsFromConfig(cwd);
+          const safeCliTools = cliTools.filter(
+            (cli) =>
+              !vendorRequiresHomeConsent(cli) || recordedVendors.includes(cli),
+          );
+          const { created } = createCliSymlinks(cwd, safeCliTools, skillNames);
           if (created.length > 0) {
             ui.note(
               created.map((s) => `${pc.green("→")} ${s}`).join("\n"),

--- a/cli/constants/vendors.ts
+++ b/cli/constants/vendors.ts
@@ -9,10 +9,19 @@ export const ALL_CLI_VENDORS: CliVendor[] = [
   "copilot",
   "cursor",
   "gemini",
+  "hermes",
   "qwen",
 ];
 
-export const CLI_SKILLS_DIR: Record<CliTool, string> = {
-  claude: ".claude/skills",
-  copilot: ".github/skills",
+export type SkillTargetBase = "project" | "home";
+
+export interface SkillTargetSpec {
+  base: SkillTargetBase;
+  path: string;
+}
+
+export const CLI_SKILLS_DIR: Record<CliTool, SkillTargetSpec> = {
+  claude: { base: "project", path: ".claude/skills" },
+  copilot: { base: "project", path: ".github/skills" },
+  hermes: { base: "home", path: ".hermes/skills/oma" },
 };

--- a/cli/platform/skills-installer.test.ts
+++ b/cli/platform/skills-installer.test.ts
@@ -18,11 +18,16 @@ vi.mock("node:fs", () => ({
   readdirSync: vi.fn(),
   readFileSync: vi.fn(),
   readlinkSync: vi.fn(),
+  realpathSync: vi.fn(),
   rmSync: vi.fn(),
   writeFileSync: vi.fn(),
   lstatSync: vi.fn(),
   unlinkSync: vi.fn(),
   symlinkSync: vi.fn(),
+}));
+
+vi.mock("node:os", () => ({
+  homedir: vi.fn(() => "/tmp/test-home"),
 }));
 
 describe("skills.ts - Workflow and Config Installation", () => {
@@ -332,6 +337,11 @@ describe("createCliSymlinks", () => {
         throw new Error("ENOENT");
       },
     );
+    // Default: realpath is identity (no symlink shenanigans). Tests that
+    // exercise path-traversal defenses override this per-test.
+    (fs.realpathSync as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (p: string) => p,
+    );
   });
 
   afterEach(() => {
@@ -471,6 +481,100 @@ describe("createCliSymlinks", () => {
     expect(fs.symlinkSync).toHaveBeenCalledTimes(2);
     expect(result.created).toContain(".claude/skills/oma-frontend");
     expect(result.created).toContain(".github/skills/oma-frontend");
+  });
+
+  // --- Hermes (HOME-base) and path-traversal defense ---
+
+  it("should create symlinks under ~/.hermes/skills/oma/ for hermes", () => {
+    (fs.existsSync as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      true,
+    );
+
+    const result = createCliSymlinks(
+      mockTargetDir,
+      ["hermes"],
+      ["oma-frontend"],
+    );
+
+    expect(fs.symlinkSync).toHaveBeenCalledWith(
+      expect.any(String),
+      "/tmp/test-home/.hermes/skills/oma/oma-frontend",
+      "dir",
+    );
+    expect(result.created).toContain(".hermes/skills/oma/oma-frontend");
+  });
+
+  it("should reject sources whose realpath escapes the SSOT base", () => {
+    (fs.existsSync as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      true,
+    );
+    (fs.realpathSync as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (p: string) => {
+        // Simulate a malicious symlink in the SSOT directory pointing
+        // outside the project (e.g., to /etc).
+        if (p.endsWith("/oma-frontend")) return "/etc/passwd";
+        return p;
+      },
+    );
+
+    const result = createCliSymlinks(
+      mockTargetDir,
+      ["claude"],
+      ["oma-frontend"],
+    );
+
+    expect(fs.symlinkSync).not.toHaveBeenCalled();
+    expect(result.skipped).toContain(
+      ".claude/skills/oma-frontend (source escapes SSOT base)",
+    );
+  });
+
+  it("should isolate hermes and project-base vendors when both selected", () => {
+    (fs.existsSync as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      true,
+    );
+
+    const result = createCliSymlinks(
+      mockTargetDir,
+      ["claude", "hermes"],
+      ["oma-frontend"],
+    );
+
+    expect(fs.symlinkSync).toHaveBeenCalledTimes(2);
+
+    const symlinkCalls = (
+      fs.symlinkSync as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls.map((c: unknown[]) => String(c[1]));
+
+    expect(symlinkCalls).toContain(
+      join(mockTargetDir, ".claude/skills/oma-frontend"),
+    );
+    expect(symlinkCalls).toContain(
+      "/tmp/test-home/.hermes/skills/oma/oma-frontend",
+    );
+
+    expect(result.created).toContain(".claude/skills/oma-frontend");
+    expect(result.created).toContain(".hermes/skills/oma/oma-frontend");
+  });
+
+  it("should skip hermes when target real directory exists", () => {
+    (fs.existsSync as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      true,
+    );
+    (fs.lstatSync as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      isSymbolicLink: () => false,
+    });
+
+    const result = createCliSymlinks(
+      mockTargetDir,
+      ["hermes"],
+      ["oma-frontend"],
+    );
+
+    expect(fs.symlinkSync).not.toHaveBeenCalled();
+    expect(result.skipped).toContain(
+      ".hermes/skills/oma/oma-frontend (real dir exists)",
+    );
   });
 });
 

--- a/cli/platform/skills-installer.ts
+++ b/cli/platform/skills-installer.ts
@@ -1,12 +1,18 @@
 import * as fs from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import { homedir } from "node:os";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import {
   ALL_CLI_VENDORS,
   CLI_SKILLS_DIR,
   INSTALLED_SKILLS_DIR,
   SKILLS,
 } from "../constants/index.js";
-import type { CliTool, CliVendor, SkillInfo } from "../types/index.js";
+import type {
+  CliTool,
+  CliVendor,
+  SkillInfo,
+  VendorType,
+} from "../types/index.js";
 import { clearNonDirectory } from "../utils/fs-utils.js";
 
 export * from "../constants/index.js";
@@ -307,6 +313,60 @@ export function installClaudeSkills(
   }
 }
 
+/**
+ * Vendors with a hook bridge (settings, prompt hooks, agent variants).
+ * Vendors NOT in this set (e.g., copilot, hermes) are skill-symlink-only
+ * and must NOT be passed to `installVendorAdaptations`.
+ */
+const HOOK_VENDORS: ReadonlySet<VendorType> = new Set([
+  "claude",
+  "codex",
+  "cursor",
+  "gemini",
+  "qwen",
+]);
+
+/**
+ * Type guard: narrows a `CliVendor` to `VendorType` if it supports
+ * hook-based vendor adaptation. Use as a `.filter()` predicate to safely
+ * derive `hookVendors` from a free-form vendor list.
+ */
+export function isHookVendor(v: CliVendor): v is VendorType {
+  return HOOK_VENDORS.has(v as VendorType);
+}
+
+/**
+ * Resolve the absolute directory where vendor skill symlinks should live.
+ *
+ * Project-base vendors live under `targetDir`; home-base vendors live under
+ * the user's HOME directory. This is the only path that produces HOME paths
+ * and is the trust boundary for HOME writes.
+ */
+function resolveCliSkillsDir(targetDir: string, cli: CliTool): string {
+  const spec = CLI_SKILLS_DIR[cli];
+  const root = spec.base === "home" ? homedir() : targetDir;
+  return join(root, spec.path);
+}
+
+/**
+ * Whether installing this vendor's skills writes outside the project
+ * directory (i.e., into the user's HOME). Callers MUST obtain explicit
+ * user consent before proceeding when this returns true.
+ */
+export function vendorRequiresHomeConsent(cli: CliTool): boolean {
+  return CLI_SKILLS_DIR[cli].base === "home";
+}
+
+/**
+ * User-facing display path for a vendor's skill directory.
+ * Home-base vendors get a `~/...` prefix; project-base vendors return
+ * the project-relative path verbatim.
+ */
+export function getVendorDisplayPath(cli: CliTool): string {
+  const spec = CLI_SKILLS_DIR[cli];
+  return spec.base === "home" ? `~/${spec.path}` : spec.path;
+}
+
 export function createCliSymlinks(
   targetDir: string,
   cliTools: CliTool[],
@@ -316,9 +376,16 @@ export function createCliSymlinks(
   const skipped: string[] = [];
   const ssotSkillsDir = resolve(targetDir, INSTALLED_SKILLS_DIR);
 
+  let realSsotBase: string;
+  try {
+    realSsotBase = fs.realpathSync(ssotSkillsDir);
+  } catch {
+    return { created, skipped };
+  }
+
   for (const cli of cliTools) {
-    const skillsDir = CLI_SKILLS_DIR[cli];
-    const linkRootDir = join(targetDir, skillsDir);
+    const skillsDir = CLI_SKILLS_DIR[cli].path;
+    const linkRootDir = resolveCliSkillsDir(targetDir, cli);
 
     if (!fs.existsSync(linkRootDir)) {
       fs.mkdirSync(linkRootDir, { recursive: true });
@@ -330,6 +397,24 @@ export function createCliSymlinks(
 
       if (!fs.existsSync(source)) {
         skipped.push(`${skillsDir}/${skillName} (source missing)`);
+        continue;
+      }
+
+      // Defense-in-depth: reject sources whose realpath escapes the SSOT
+      // base. Prevents path traversal via malicious symlinks in
+      // `.agents/skills/`.
+      let realSource: string;
+      try {
+        realSource = fs.realpathSync(source);
+      } catch {
+        skipped.push(`${skillsDir}/${skillName} (source unreadable)`);
+        continue;
+      }
+      if (
+        realSource !== realSsotBase &&
+        !realSource.startsWith(realSsotBase + sep)
+      ) {
+        skipped.push(`${skillsDir}/${skillName} (source escapes SSOT base)`);
         continue;
       }
 
@@ -371,9 +456,9 @@ export function getInstalledSkillNames(targetDir: string): string[] {
 
 export function detectExistingCliSymlinkDirs(targetDir: string): CliTool[] {
   const tools: CliTool[] = [];
-  for (const [cli, dir] of Object.entries(CLI_SKILLS_DIR)) {
-    if (fs.existsSync(join(targetDir, dir))) {
-      tools.push(cli as CliTool);
+  for (const cli of Object.keys(CLI_SKILLS_DIR) as CliTool[]) {
+    if (fs.existsSync(resolveCliSkillsDir(targetDir, cli))) {
+      tools.push(cli);
     }
   }
   return tools;

--- a/cli/platform/vendor-config.test.ts
+++ b/cli/platform/vendor-config.test.ts
@@ -43,6 +43,7 @@ describe("readVendorsFromConfig", () => {
       "copilot",
       "cursor",
       "gemini",
+      "hermes",
       "qwen",
     ]);
   });
@@ -56,6 +57,7 @@ describe("readVendorsFromConfig", () => {
       "copilot",
       "cursor",
       "gemini",
+      "hermes",
       "qwen",
     ]);
   });

--- a/cli/types/vendors.ts
+++ b/cli/types/vendors.ts
@@ -1,10 +1,11 @@
 export type VendorType = "claude" | "codex" | "cursor" | "gemini" | "qwen";
 
-/** All CLI tools including non-hook vendors. */
-export type CliVendor = VendorType | "copilot";
-
 /** CLI tools that support skill symlinking. */
-export type CliTool = "claude" | "copilot";
+export const CLI_TOOLS = ["claude", "copilot", "hermes"] as const;
+export type CliTool = (typeof CLI_TOOLS)[number];
+
+/** All CLI tools including non-hook vendors. */
+export type CliVendor = VendorType | "copilot" | "hermes";
 
 export interface CLICheck {
   name: string;


### PR DESCRIPTION
Resolves #304.

## Summary

Hermes Agent (NousResearch) joins oma as a `CliTool` with `base: "home"` — the
first oma vendor to symlink skills into `~/.hermes/skills/oma/`. Designed
through `/brainstorm` → `/plan` → `/ultrawork` (5 phases, 11 reviews).

## Architecture

- `CLI_SKILLS_DIR` extends from `Record<CliTool, string>` to
  `Record<CliTool, SkillTargetSpec { base: "project" | "home", path }>` —
  hermes reuses the existing `createCliSymlinks` machinery via
  `resolveCliSkillsDir`. No hermes-specific function.
- **Consent SSOT**: `oma-config.yaml`'s `vendors:` list. `oma install` prompts
  and writes the record; `oma update`/`oma link` read the record and never
  re-prompt.
- `isHookVendor` type guard consolidates 3 duplicate `hookVendors` filters
  (install/update/link) and prevents `copilot`/`hermes` from leaking into
  `installVendorAdaptations`.
- **Workflows NOT exported** — hermes hooks are non-blocking by design
  (`gateway/hooks.py`: "Errors in hooks are caught and logged but never
  block the main pipeline"), so persistent-mode workflows like
  `orchestrate`/`ultrawork` cannot execute. Limitation surfaced *pre-install*
  in `vendorOptions.hint`.

## Security

- `realpath` validation in `createCliSymlinks` rejects sources whose
  canonical path escapes `.agents/skills/` (path traversal defense, applied
  to **all** vendors as defense-in-depth).
- Default-off for HOME-base vendors in multiselect — existing-user surprise
  prevention.
- Auto-excluded on Windows (no symlink permissions) and CI
  (`HOME=/root` unreliable in containers).

## UX

- multiselect hint surfaces three constraints up-front:
  `skills only — workflows N/A, HOME-shared (no per-project isolation)`
- `Cancel` (Ctrl+C) at consent → full install cancellation
  (consistent with other prompts).
- `No` at consent → skip hermes only, continue install.

## Tests

- **1089/1089 pass** (8 new):
  - `skills-installer.test.ts`: 4 cases (hermes HOME write, realpath
    rejection, mixed vendor isolation, real-dir conflict skip)
  - `install-home-policy.test.ts` (renamed from `install-home-guard`):
    4 cases (consent Y/N flows, HOME isolation, hookVendors leak prevention)
- 25 file-system integration checks via standalone harness
- 10 Flow 4 (update gate) scenario checks: never-consented, previously-consented,
  explicit-revocation

## Out of Scope (follow-ups)

- `oma unlink --vendor hermes` — uninstall command (separate UX scope)
- Hermes version compatibility detection (speculative)
- TOCTOU hardening (HOME perms 700 limits attack surface)
- XDG / macOS Application Support base for future vendors

## Pre-existing Issues Discovered (NOT fixed in this PR)

These were surfaced during manual verification but **predate** this PR. Will
file as separate issues:

1. **`oma-config.yaml` not auto-created on fresh install** — `installConfigs`
   only copies `.agents/config/*` and `mcp.json`, never the top-level
   `oma-config.yaml`. The patch logic at `install.ts:570` is gated on
   `existsSync(userPrefsPath)`, so fresh projects skip it. Our consent gate
   degrades gracefully (state-based fallback via
   `detectExistingCliSymlinkDirs`), but `language`/`model_preset`/`vendors`
   are not persisted for fresh users.
2. **`doctor` `src and dest cannot be the same` error** when post-install
   "Install missing skills?" tries to copy `_shared` from cwd to cwd.

## Verification

- [x] `bun run --cwd cli typecheck`
- [x] `bun run --cwd cli lint` (Biome clean)
- [x] `bun run --cwd cli test` (1089/1089)
- [x] Manual install with consent Y → `~/.hermes/skills/oma/` populated
      (12 skills, no workflows)
- [x] Integration harness (25 fs checks)
- [x] Flow 4 update-gate scenarios (10 checks)
