### PR TITLE
fix(install,doctor): bootstrap oma-config.yaml + fix doctor missing-skill repair

### DIFF
--- a/cli/commands/doctor/doctor.ts
+++ b/cli/commands/doctor/doctor.ts
@@ -1,6 +1,7 @@
 import { execSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { downloadAndExtract } from "../../io/tarball.js";
 import {
   getAllSkills,
   INSTALLED_SKILLS_DIR,
@@ -196,14 +197,28 @@ export function serializeReportAsJson(report: DoctorReport): string {
   return JSON.stringify(payload, null, 2);
 }
 
-export function installMissingSkills(
-  cwd: string,
+/**
+ * Download a fresh source tarball and install the named skills into
+ * `targetDir`. Doctor uses this to repair missing/incomplete skills
+ * detected during diagnosis. Network is required only on this path —
+ * the diagnosis-only flow stays offline.
+ *
+ * Replaces the prior `installShared(cwd, cwd)` anti-pattern that always
+ * threw `src and dest cannot be the same`.
+ */
+export async function installSkillsFromRemote(
+  targetDir: string,
   skillNames: string[],
   onProgress?: (name: string) => void,
-): void {
-  installShared(cwd, cwd);
-  for (const name of skillNames) {
-    onProgress?.(name);
-    installSkill(cwd, name, cwd);
+): Promise<void> {
+  const { dir: repoDir, cleanup } = await downloadAndExtract();
+  try {
+    installShared(repoDir, targetDir);
+    for (const name of skillNames) {
+      onProgress?.(name);
+      installSkill(repoDir, name, targetDir);
+    }
+  } finally {
+    cleanup();
   }
 }

--- a/cli/commands/doctor/install-skills.test.ts
+++ b/cli/commands/doctor/install-skills.test.ts
@@ -1,0 +1,119 @@
+// Unit tests for installSkillsFromRemote — doctor's repair flow.
+//
+// Covers:
+//   1. Downloads source via downloadAndExtract before installing
+//   2. Calls installShared with the EXTRACTED dir (not cwd) — regression
+//      guard for the prior `installShared(cwd, cwd)` crash bug
+//   3. Calls installSkill per name with extracted dir as source
+//   4. Always invokes cleanup() — even if installation throws
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tarballState = vi.hoisted(() => ({
+  cleanup: vi.fn(),
+  downloadAndExtract: vi.fn(async () => ({
+    dir: "/tmp/extracted-source",
+    cleanup: tarballState.cleanup,
+  })),
+}));
+
+const skillsState = vi.hoisted(() => ({
+  installShared: vi.fn(),
+  installSkill: vi.fn(() => true),
+  getAllSkills: vi.fn(() => []),
+  INSTALLED_SKILLS_DIR: ".agents/skills",
+}));
+
+vi.mock("../../io/tarball.js", () => tarballState);
+vi.mock("../../platform/skills-installer.js", () => skillsState);
+
+vi.mock("../../vendors/index.js", () => ({
+  isClaudeAuthenticated: vi.fn(() => false),
+  isCodexAuthenticated: vi.fn(() => false),
+  isGeminiAuthenticated: vi.fn(() => false),
+  isQwenAuthenticated: vi.fn(() => false),
+}));
+
+import { installSkillsFromRemote } from "./doctor.js";
+
+describe("installSkillsFromRemote", () => {
+  const target = "/tmp/test-project";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tarballState.cleanup = vi.fn();
+    tarballState.downloadAndExtract.mockResolvedValue({
+      dir: "/tmp/extracted-source",
+      cleanup: tarballState.cleanup,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("downloads the source tarball before installing", async () => {
+    await installSkillsFromRemote(target, ["oma-frontend"]);
+    expect(tarballState.downloadAndExtract).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls installShared with extracted source dir, not cwd (regression for src=dest crash)", async () => {
+    await installSkillsFromRemote(target, ["oma-frontend"]);
+    expect(skillsState.installShared).toHaveBeenCalledWith(
+      "/tmp/extracted-source",
+      target,
+    );
+    // Critical: the SOURCE must NOT equal the target
+    const call = skillsState.installShared.mock.calls[0];
+    expect(call[0]).not.toBe(call[1]);
+  });
+
+  it("installs each named skill with extracted source dir", async () => {
+    await installSkillsFromRemote(target, [
+      "oma-frontend",
+      "oma-backend",
+      "oma-mobile",
+    ]);
+    expect(skillsState.installSkill).toHaveBeenCalledTimes(3);
+    for (const call of skillsState.installSkill.mock.calls) {
+      expect(call[0]).toBe("/tmp/extracted-source"); // sourceDir
+      expect(call[2]).toBe(target); // targetDir
+      expect(call[0]).not.toBe(call[2]); // src != dest
+    }
+  });
+
+  it("invokes onProgress for each skill", async () => {
+    const onProgress = vi.fn();
+    await installSkillsFromRemote(
+      target,
+      ["oma-frontend", "oma-backend"],
+      onProgress,
+    );
+    expect(onProgress).toHaveBeenCalledWith("oma-frontend");
+    expect(onProgress).toHaveBeenCalledWith("oma-backend");
+  });
+
+  it("calls cleanup even when installSkill throws", async () => {
+    skillsState.installSkill.mockImplementationOnce(() => {
+      throw new Error("disk full");
+    });
+
+    await expect(
+      installSkillsFromRemote(target, ["oma-frontend"]),
+    ).rejects.toThrow("disk full");
+
+    expect(tarballState.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls cleanup even when installShared throws", async () => {
+    skillsState.installShared.mockImplementationOnce(() => {
+      throw new Error("permission denied");
+    });
+
+    await expect(
+      installSkillsFromRemote(target, ["oma-frontend"]),
+    ).rejects.toThrow("permission denied");
+
+    expect(tarballState.cleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/cli/commands/doctor/ui.ts
+++ b/cli/commands/doctor/ui.ts
@@ -6,7 +6,7 @@ import { printMigrationGuide } from "../../vendors/qwen/auth.js";
 import {
   AUTH_CHECKERS,
   type DoctorReport,
-  installMissingSkills,
+  installSkillsFromRemote,
 } from "./doctor.js";
 import type { ProfileReport } from "./profile.js";
 
@@ -137,9 +137,9 @@ async function promptRepair(report: DoctorReport): Promise<void> {
   }
 
   const spinner = p.spinner();
-  spinner.start("Installing skills...");
+  spinner.start("Downloading source...");
   try {
-    installMissingSkills(report.cwd, skillsToInstall, (name) => {
+    await installSkillsFromRemote(report.cwd, skillsToInstall, (name) => {
       spinner.message(`Installing ${pc.cyan(name)}...`);
     });
     spinner.stop(`Installed ${skillsToInstall.length} skill(s)!`);

--- a/cli/platform/skills-installer.test.ts
+++ b/cli/platform/skills-installer.test.ts
@@ -133,6 +133,54 @@ describe("skills.ts - Workflow and Config Installation", () => {
       const mcpDest = join(mockTargetDir, ".agents", "mcp.json");
       expect(fs.cpSync).toHaveBeenCalledWith(mcpSrc, mcpDest);
     });
+
+    it("creates oma-config.yaml on fresh install when missing", () => {
+      const omaConfigSrc = join(mockSourceDir, ".agents", "oma-config.yaml");
+      const omaConfigDest = join(mockTargetDir, ".agents", "oma-config.yaml");
+
+      (fs.existsSync as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+        (p: string) => {
+          if (p === omaConfigSrc) return true;
+          if (p === omaConfigDest) return false; // missing on target
+          return true;
+        },
+      );
+      (fs.readdirSync as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+        [],
+      );
+
+      installConfigs(mockSourceDir, mockTargetDir, false);
+
+      expect(fs.cpSync).toHaveBeenCalledWith(omaConfigSrc, omaConfigDest);
+    });
+
+    it("preserves existing oma-config.yaml without force", () => {
+      // existsSync returns true for everything → dest exists → no copy
+      (fs.existsSync as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+        true,
+      );
+      (fs.readdirSync as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+        [],
+      );
+
+      installConfigs(mockSourceDir, mockTargetDir, false);
+
+      const omaConfigSrc = join(mockSourceDir, ".agents", "oma-config.yaml");
+      const omaConfigDest = join(mockTargetDir, ".agents", "oma-config.yaml");
+      expect(fs.cpSync).not.toHaveBeenCalledWith(omaConfigSrc, omaConfigDest);
+    });
+
+    it("overwrites oma-config.yaml with force flag", () => {
+      (fs.existsSync as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+        true,
+      );
+
+      installConfigs(mockSourceDir, mockTargetDir, true);
+
+      const omaConfigSrc = join(mockSourceDir, ".agents", "oma-config.yaml");
+      const omaConfigDest = join(mockTargetDir, ".agents", "oma-config.yaml");
+      expect(fs.cpSync).toHaveBeenCalledWith(omaConfigSrc, omaConfigDest);
+    });
   });
 });
 

--- a/cli/platform/skills-installer.ts
+++ b/cli/platform/skills-installer.ts
@@ -237,6 +237,19 @@ export function installConfigs(
       fs.cpSync(mcpSrc, mcpDest);
     }
   }
+
+  // Bootstrap oma-config.yaml on fresh installs so language/model_preset/
+  // vendors patches downstream have a file to operate on. User edits are
+  // preserved unless `force` is true.
+  const omaConfigSrc = join(sourceDir, ".agents", "oma-config.yaml");
+  if (fs.existsSync(omaConfigSrc)) {
+    const agentDir = join(targetDir, ".agents");
+    fs.mkdirSync(agentDir, { recursive: true });
+    const omaConfigDest = join(agentDir, "oma-config.yaml");
+    if (force || !fs.existsSync(omaConfigDest)) {
+      fs.cpSync(omaConfigSrc, omaConfigDest);
+    }
+  }
 }
 
 export function installGlobalWorkflows(sourceDir: string): void {


### PR DESCRIPTION
Two pre-existing install/doctor bugs surfaced during #305 verification.
Each bug is fixed in a dedicated commit so they can be reverted
independently if needed.

## Commit 1 — `fix(install): create oma-config.yaml on fresh installs`

### Symptom
After `oma install` on a fresh project, `.agents/oma-config.yaml` doesn't
exist. Subsequent `oma install`/`oma update` runs always re-prompt with
defaults because `getExistingLanguage` and `getExistingPreset` find
nothing to read.

### Root cause
`installConfigs` (`cli/platform/skills-installer.ts`) only copies
`.agents/config/*` and `.agents/mcp.json`. The top-level
`.agents/oma-config.yaml` is never copied. The post-install patch block
at `cli/commands/install/install.ts:570` is gated on
`existsSync(userPrefsPath)`, so it silently no-ops on fresh projects.
`writeVendorsToConfig` short-circuits the same way.

### Fix
Extend `installConfigs` to copy `oma-config.yaml` mirroring the existing
`mcp.json` pattern:
- creates the file when missing,
- preserves user customizations (no overwrite without `force: true`),
- copies fresh on `force` to support `oma update --force`.

### Tests
3 new cases in `installConfigs` describe block:
- creates `oma-config.yaml` on fresh install
- preserves existing file without force
- overwrites with force flag

## Commit 2 — `fix(doctor): repair missing skills via downloadAndExtract instead of cwd-cwd copy`

### Symptom
After `oma install`, doctor offers "Found N missing/incomplete skill(s).
Install them?" Selecting Yes fails immediately with:
```
src and dest cannot be the same /path/to/.agents/skills/_shared
```

### Root cause
`installMissingSkills(cwd, names, ...)` called
`installShared(cwd, cwd)` and `installSkill(cwd, name, cwd)` —
sourceDir === targetDir. Since `INSTALLED_SKILLS_DIR === ".agents/skills"`,
the destination always equals the source and `fs.cpSync` rejects.

The pattern regressed in `59f7f1c` (refactor splitting doctor into
`{command,doctor,ui}`) which carried over the broken `installShared(cwd, cwd)`
form from an earlier `installShared(cwd)` single-arg signature. The
function has been unreachable-without-crash for ~3 months.

### Fix — preserve repair UX with proper source

Replace `installMissingSkills` with `installSkillsFromRemote`:
- Downloads a fresh source tarball via `downloadAndExtract`
- Installs `_shared` + named skills with the extracted dir as source
- `try`/`finally` cleanup so partial failures don't leak temp dirs

UI flow preserved end-to-end (confirm → select-all/individual → spinner
with per-skill progress). Network is required only on the Yes path;
default diagnosis flow stays offline.

### Architectural rationale

Considered Option A (remove the broken feature, point users to `oma update`)
vs Option B (this — fix it properly with `downloadAndExtract`). Decision
factors (ATAM/SOLID lens):

- **Functional Suitability**: Option B preserves the original 1-click repair UX
- **DRY**: `downloadAndExtract`/`installShared`/`installSkill` are reused, not
  duplicated
- **SRP**: doctor's repair scope stays narrow (missing skills only); large
  version updates remain `oma update`'s domain
- **Reliability**: network dependency is opt-in (only on Yes), default flow
  remains offline
- **Cost**: +144 / −10 (net +134) — most of which is regression tests
  including a critical `sourceDir !== targetDir` invariant guard

### Tests
6 new cases in `install-skills.test.ts`:
- downloads source before installing
- **regression guard**: `installShared` source ≠ target (prevents the bug
  class)
- **regression guard**: each `installSkill` source ≠ target
- per-skill progress callback
- cleanup invoked even when `installSkill` throws
- cleanup invoked even when `installShared` throws

## Verification

- [x] `bun run --cwd cli typecheck`
- [x] `bun run --cwd cli lint` (Biome clean)
- [x] `bun run --cwd cli test` — 1124 pass (1118 baseline + 3 from Bug 1 + 6 from Bug 2)
- [x] Diff: 5 files, +205/-10

## Discovered by

Manual verification of #305 (Hermes Agent skill export). PR #305 explicitly
flagged both bugs in its body and noted they predate that PR.

## Out of scope

- Backfilling `oma-config.yaml` for existing installs that lack it —
  next `oma install`/`oma update` cycle creates it via the new
  `installConfigs` behavior.
