### PR TITLE
feat(migrations): add manual legacy migration command

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "oh-my-agent-workspace",
+      "dependencies": {
+        "pptxgenjs": "^4.0.1",
+      },
       "devDependencies": {
         "@biomejs/biome": "^2.4.15",
         "@commitlint/cli": "20.4.3",
@@ -13,7 +16,7 @@
     },
     "cli": {
       "name": "oh-my-agent",
-      "version": "8.9.0",
+      "version": "8.16.0",
       "bin": {
         "oh-my-agent": "./bin/cli.js",
         "oma": "./bin/cli.js",
@@ -58,7 +61,7 @@
     },
     "web": {
       "name": "web",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "dependencies": {
         "@docusaurus/core": "3.10.1",
         "@docusaurus/faster": "3.10.1",
@@ -2535,7 +2538,7 @@
 
     "postcss-zindex": ["postcss-zindex@6.0.2", "", { "peerDependencies": { "postcss": "^8.4.31" } }, "sha512-5BxW9l1evPB/4ZIc+2GobEBoKC+h8gPGCMi+jxsYvd2x0mjq7wazk6DrP71pStqxE9Foxh5TVnonbWpFZzXaYg=="],
 
-    "pptxgenjs": ["pptxgenjs@3.12.0", "", { "dependencies": { "@types/node": "^18.7.3", "https": "^1.0.0", "image-size": "^1.0.0", "jszip": "^3.7.1" } }, "sha512-ZozkYKWb1MoPR4ucw3/aFYlHkVIJxo9czikEclcUVnS4Iw/M+r+TEwdlB3fyAWO9JY1USxJDt0Y0/r15IR/RUA=="],
+    "pptxgenjs": ["pptxgenjs@4.0.1", "", { "dependencies": { "@types/node": "^22.8.1", "https": "^1.0.0", "image-size": "^1.2.1", "jszip": "^3.10.1" } }, "sha512-TeJISr8wouAuXw4C1F/mC33xbZs/FuEG6nH9FG1Zj+nuPcGMP5YRHl6X+j3HSUnS1f3at6k75ZZXPMZlA5Lj9A=="],
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 
@@ -3330,6 +3333,8 @@
     "mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "null-loader/schema-utils": ["schema-utils@3.3.0", "", { "dependencies": { "@types/json-schema": "^7.0.8", "ajv": "^6.12.5", "ajv-keywords": "^3.5.2" } }, "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg=="],
+
+    "oh-my-agent/pptxgenjs": ["pptxgenjs@3.12.0", "", { "dependencies": { "@types/node": "^18.7.3", "https": "^1.0.0", "image-size": "^1.0.0", "jszip": "^3.7.1" } }, "sha512-ZozkYKWb1MoPR4ucw3/aFYlHkVIJxo9czikEclcUVnS4Iw/M+r+TEwdlB3fyAWO9JY1USxJDt0Y0/r15IR/RUA=="],
 
     "pac-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -14,6 +14,7 @@ import {
 import { registerLink } from "./commands/link/command.js";
 import { registerMarketCommand } from "./commands/market/index.js";
 import { registerMemory } from "./commands/memory/command.js";
+import { registerMigrate } from "./commands/migrations/command.js";
 import { registerModelCommands } from "./commands/model/command.js";
 import { registerRecap } from "./commands/recap/command.js";
 import { registerRetro } from "./commands/retro/command.js";
@@ -120,6 +121,7 @@ registerSkillsCommand(program);
 registerSlideCommand(program);
 registerScholarCommand(program);
 registerImageCommand(program);
+registerMigrate(program);
 
 program
   .command("help")

--- a/cli/commands/migrations/command.test.ts
+++ b/cli/commands/migrations/command.test.ts
@@ -1,0 +1,83 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerMigrate } from "./command.js";
+
+const runMigrationsMock = vi.hoisted(() => vi.fn((): string[] => []));
+
+vi.mock("./index.js", () => ({
+  runMigrations: runMigrationsMock,
+}));
+
+function makeProgram(): Command {
+  const program = new Command();
+  registerMigrate(program);
+  return program;
+}
+
+describe("migrate command", () => {
+  beforeEach(() => {
+    runMigrationsMock.mockReset();
+    runMigrationsMock.mockReturnValue([]);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it("runs gemini-cli migrations and reports a no-op", async () => {
+    await makeProgram().parseAsync([
+      "node",
+      "oma",
+      "migrate",
+      "--from",
+      "gemini-cli",
+    ]);
+
+    expect(runMigrationsMock).toHaveBeenCalledWith(process.cwd());
+    expect(console.log).toHaveBeenCalledWith(
+      "Running migrations from gemini-cli...",
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      "No legacy configurations to migrate.",
+    );
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("prints every completed migration action", async () => {
+    runMigrationsMock.mockReturnValue(["first action", "second action"]);
+
+    await makeProgram().parseAsync([
+      "node",
+      "oma",
+      "migrate",
+      "--from",
+      "gemini-cli",
+    ]);
+
+    expect(console.log).toHaveBeenCalledWith(
+      "Migration completed successfully:",
+    );
+    expect(console.log).toHaveBeenCalledWith("- first action");
+    expect(console.log).toHaveBeenCalledWith("- second action");
+  });
+
+  it("rejects unsupported migration sources", async () => {
+    await makeProgram().parseAsync([
+      "node",
+      "oma",
+      "migrate",
+      "--from",
+      "unknown",
+    ]);
+
+    expect(runMigrationsMock).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "Error: Only migration '--from gemini-cli' is supported.",
+    );
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/cli/commands/migrations/command.ts
+++ b/cli/commands/migrations/command.ts
@@ -1,0 +1,36 @@
+import type { Command } from "commander";
+import { runAction } from "../../utils/cli-framework.js";
+import { runMigrations } from "./index.js";
+
+type MigrateOptions = {
+  from?: string;
+};
+
+export function registerMigrate(program: Command): void {
+  program
+    .command("migrate")
+    .description("Migrate configurations from legacy environments")
+    .option(
+      "--from <source>",
+      "Legacy source to migrate from (e.g. gemini-cli)",
+    )
+    .action(
+      runAction((options: MigrateOptions) => {
+        if (options.from !== "gemini-cli") {
+          throw new Error(
+            "Error: Only migration '--from gemini-cli' is supported.",
+          );
+        }
+        console.log("Running migrations from gemini-cli...");
+        const actions = runMigrations(process.cwd());
+        if (actions.length === 0) {
+          console.log("No legacy configurations to migrate.");
+          return;
+        }
+        console.log("Migration completed successfully:");
+        for (const action of actions) {
+          console.log(`- ${action}`);
+        }
+      }),
+    );
+}

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "@commitlint/cli": "20.4.3",
     "@commitlint/config-conventional": "20.4.3",
     "husky": "9.1.7"
+  },
+  "dependencies": {
+    "pptxgenjs": "^4.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- add a manual `oma migrate` command for legacy configuration migration
- expose migration options through the CLI entrypoint
- add focused command tests
- update the workspace `pptxgenjs` dependency used by the current toolchain

## Validation
- `bun run --cwd cli test commands/migrations/command.test.ts commands/migrations/migrate.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- pre-push hook: `2240 passed`, `1 skipped`, `1 todo`