### PR TITLE
Pi 지원 추가

### DIFF
--- a/.agents/hooks/variants/pi/README.md
+++ b/.agents/hooks/variants/pi/README.md
@@ -49,11 +49,14 @@ uses), rather than forcing continuation within a single turn.
 (`.agents/hooks/core/constants.ts`) so the `Vendor` dialect in `hook-output.ts`
 can emit pi-native shapes. It is intentionally **absent** from the cli-runtime
 `VENDORS` (`cli/constants/vendors.ts`), which drives the settings-file install
-that does not apply to pi.
+that does not apply to pi. The CLI spawn path still supports `-m pi` through the
+runtime-dispatch external CLI config; it invokes `pi -p` as a subprocess rather
+than a native subagent API.
 
 ## Enabling
 
 Add `pi` to the `vendors:` block in `.agents/oma-config.yaml`, then run
 `oma link` (or `oma install` / `oma update`). The bridge is regenerated into
-`.pi/extensions/oma/` on every link. pi picks up changes on `/reload` or next
+`.pi/extensions/oma/` and workflow prompt wrappers are regenerated into
+`.pi/prompts/` on every link. pi picks up extension changes on `/reload` or next
 launch.

--- a/.agents/skills/_shared/runtime/execution-protocols/pi.md
+++ b/.agents/skills/_shared/runtime/execution-protocols/pi.md
@@ -1,0 +1,63 @@
+# Execution Protocol (pi)
+
+When running as a CLI subagent (`pi -p` headless print mode), follow this protocol for shared state coordination. **In headless mode your stdout is captured in the spawner log, but the orchestrator reads only the result artifact below.** If you do not write it, the orchestrator reports your run as `crashed` even on success.
+
+## State Management
+
+Use file-based I/O for coordination. Coordination/state files (task-board, progress,
+result hand-offs) MUST be written to the **project-root memory store** `.serena/memories/`
+— that is the only location the orchestrator (`oma agent:status`), `oma verify`, and the
+memory/retro tooling read. Writing them anywhere else (e.g. `.agents/results/`) leaves them
+orphaned and your run is reported as `crashed`. Human-facing deliverables (plans, bug
+reports, design docs) belong under `.agents/results/` instead.
+
+If Serena MCP is available, use `read_memory`/`write_memory`/`edit_memory` (its default
+base path is `.serena/memories`); otherwise write the same files there directly with pi's
+`read`, `write`, or `edit` tools.
+
+### Path Resolution (CRITICAL)
+
+All result, progress, and state files MUST be written to the **project root** `.serena/memories/` directory, never to a subdirectory's `.serena/memories/`.
+
+- **Project root** = the git repository root (where `.git` exists)
+- **Session-scoped naming**: when running under an orchestration session, append session ID as suffix:
+  - `result-{agent-id}-{sessionId}.md` (e.g., `result-frontend-session-20260405-100835.md`)
+  - `progress-{agent-id}-{sessionId}.md`
+- **Manual (non-orchestrated) runs**: no suffix, `result-{agent-id}.md`
+
+## On Start
+
+1. Read `.serena/memories/task-board.md` (or `read_memory("task-board.md")`) to confirm your assigned task when it exists.
+2. Create `.serena/memories/progress-{agent-id}[-{sessionId}].md` with initial status.
+
+## During Execution
+
+- Periodically update `progress-{agent-id}[-{sessionId}].md` with current state.
+- Include: action taken, current status, files created/modified.
+
+## On Completion
+
+- Create `.serena/memories/result-{agent-id}[-{sessionId}].md` with final result including:
+  - A status line — see **Status line format** below (REQUIRED)
+  - Summary of work done
+  - Files created/modified
+  - Acceptance criteria checklist
+
+## On Failure
+
+- Still create `result-{agent-id}[-{sessionId}].md` with the status line set to `failed`.
+- Include detailed error description and what remains incomplete.
+
+## Status line format (REQUIRED)
+
+The orchestrator parses the status with the regex `^## Status:\s*(\S+)`. The result file
+MUST contain a single line in exactly this shape — heading marker, colon on the same line,
+plain word, no backticks, no quotes:
+
+```
+## Status: completed
+```
+
+Use `## Status: failed` on failure. Do NOT split it across lines or render it as a
+sub-bullet (e.g. `- Status: completed`) — that fails to parse and a failed run would be
+silently misreported as completed.

--- a/.agents/skills/oma-orchestrator/config/cli-config.yaml
+++ b/.agents/skills/oma-orchestrator/config/cli-config.yaml
@@ -80,6 +80,15 @@ vendors:
     default_model: "auto"
     isolation_method: "directory"
 
+  # pi headless print mode: `pi [--model …] -p "<prompt>"`.
+  # Model accepts any pi model pattern/alias, including thinking suffixes.
+  pi:
+    command: pi
+    prompt_flag: "-p"
+    model_flag: "--model"
+    default_model: "sonnet:high"
+    isolation_method: "directory"
+
 # SubAgent execution settings
 execution:
   # Directory for subagent results

--- a/cli/__tests__/pi-extension.test.ts
+++ b/cli/__tests__/pi-extension.test.ts
@@ -1,4 +1,11 @@
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -12,6 +19,7 @@ import {
   installPiExtension,
   PI_EXTENSION_DIR,
 } from "../platform/pi-extension-composer.js";
+import { installPiPromptTemplates } from "../platform/pi-prompts.js";
 
 const REPO_ROOT = join(__dirname, "../..");
 
@@ -77,6 +85,34 @@ describe("installPiExtension", () => {
  * (subprocess spawn → JSON parse → systemPrompt assembly / in-place command
  * rewrite) without depending on keyword config or mutating the repo.
  */
+describe("installPiPromptTemplates", () => {
+  let target: string;
+
+  beforeEach(() => {
+    target = mkdtempSync(join(tmpdir(), "oma-pi-prompts-"));
+  });
+
+  it("materializes workflow slash-command wrappers", () => {
+    const written = installPiPromptTemplates(REPO_ROOT, target);
+    const workPrompt = join(target, ".pi", "prompts", "work.md");
+    expect(written).toContain(join(".pi", "prompts", "work.md"));
+    expect(existsSync(workPrompt)).toBe(true);
+    rmSync(target, { recursive: true, force: true });
+  });
+
+  it("does not overwrite user-authored pi prompts", () => {
+    const promptDir = join(target, ".pi", "prompts");
+    const workPrompt = join(promptDir, "work.md");
+    mkdirSync(promptDir, { recursive: true });
+    writeFileSync(workPrompt, "custom user prompt");
+
+    installPiPromptTemplates(REPO_ROOT, target);
+
+    expect(readFileSync(workPrompt, "utf-8")).toBe("custom user prompt");
+    rmSync(target, { recursive: true, force: true });
+  });
+});
+
 describe("pi bridge handlers", () => {
   let target: string;
   let extDir: string;

--- a/cli/commands/agent/command.ts
+++ b/cli/commands/agent/command.ts
@@ -10,7 +10,7 @@ export function registerAgentCommands(program: Command): void {
     .description("Spawn a subagent (prompt can be inline text or a file path)")
     .option(
       "-m, --model <vendor>",
-      "CLI vendor override (antigravity/claude/codex/cursor/qwen/grok)",
+      "CLI vendor override (antigravity/claude/codex/cursor/qwen/grok/pi)",
     )
     .option(
       "-w, --workspace <path>",
@@ -49,7 +49,7 @@ export function registerAgentCommands(program: Command): void {
     .description("Run multiple sub-agents in parallel")
     .option(
       "-m, --model <vendor>",
-      "CLI vendor override (antigravity/claude/codex/cursor/qwen/grok)",
+      "CLI vendor override (antigravity/claude/codex/cursor/qwen/grok/pi)",
     )
     .option(
       "-i, --inline",

--- a/cli/commands/link/__tests__/link.test.ts
+++ b/cli/commands/link/__tests__/link.test.ts
@@ -17,6 +17,14 @@ vi.mock("../../../platform/rules.js", () => ({
   mergeRulesIndexForVendor: vi.fn(() => true),
 }));
 
+vi.mock("../../../platform/pi-extension-composer.js", () => ({
+  installPiExtension: vi.fn(),
+}));
+
+vi.mock("../../../platform/pi-prompts.js", () => ({
+  installPiPromptTemplates: vi.fn(() => []),
+}));
+
 vi.mock("../../../platform/skills-installer.js", () => ({
   createVendorSymlinks: vi.fn(() => ({ created: [], skipped: [] })),
   createVendorWorkflowSymlinks: vi.fn(() => ({ created: [], skipped: [] })),
@@ -76,6 +84,9 @@ vi.mock("../../../vendors/qwen/settings.js", () => ({
   needsQwenSettingsUpdate: vi.fn(() => false),
 }));
 
+import * as piExtension from "../../../platform/pi-extension-composer.js";
+import * as piPrompts from "../../../platform/pi-prompts.js";
+import * as rules from "../../../platform/rules.js";
 import * as skills from "../../../platform/skills-installer.js";
 import * as safeWrite from "../../../utils/safe-write.js";
 import * as antigravity from "../../../vendors/antigravity/hud.js";
@@ -197,6 +208,29 @@ describe("link kernel", () => {
 
       expect(result.vendors).toEqual([]);
       expect(skills.installVendorAdaptations).not.toHaveBeenCalled();
+    });
+
+    it("links pi-only projects through the extension path", () => {
+      const projectDir = makeProject(["pi"]);
+      process.chdir(projectDir);
+
+      const result = link({ quiet: true });
+
+      expect(piExtension.installPiExtension).toHaveBeenCalledWith(
+        expect.stringContaining("oma-link-test-"),
+        expect.stringContaining("oma-link-test-"),
+      );
+      expect(piPrompts.installPiPromptTemplates).toHaveBeenCalledWith(
+        expect.stringContaining("oma-link-test-"),
+        expect.stringContaining("oma-link-test-"),
+      );
+      expect(rules.mergeRulesIndexForVendor).toHaveBeenCalledWith(
+        expect.stringContaining("oma-link-test-"),
+        "pi",
+      );
+      expect(skills.installVendorAdaptations).not.toHaveBeenCalled();
+      expect(result.vendors).toEqual([]);
+      expect(result.mergedDocs).toEqual(["AGENTS.md"]);
     });
   });
 

--- a/cli/commands/link/link.ts
+++ b/cli/commands/link/link.ts
@@ -5,6 +5,7 @@ import { VENDORS } from "../../constants/vendors.js";
 import { ensureOmaProjectGitignore } from "../../io/gitignore.js";
 import { getInstallMode } from "../../platform/install-context.js";
 import { installPiExtension } from "../../platform/pi-extension-composer.js";
+import { installPiPromptTemplates } from "../../platform/pi-prompts.js";
 import {
   applyCursorRules,
   mergeRulesIndexForVendor,
@@ -156,8 +157,8 @@ export function link(opts: LinkOptions = {}): LinkResult {
       : readVendorsFromConfig(cwd);
   const hookVendors = configuredVendors.filter(isHookVendor);
   // Extension-model vendors (pi) install via a forked path, not the
-  // settings-file hook flow. They are not in the CliVendor union, so match on
-  // the raw configured strings.
+  // settings-file hook flow. Match through the extension-vendor guard so they
+  // stay out of the hook-vendor pipeline.
   const extensionVendors = (configuredVendors as readonly string[]).filter(
     isExtensionVendor,
   );
@@ -170,17 +171,24 @@ export function link(opts: LinkOptions = {}): LinkResult {
   }
 
   // Install in-process extension vendors (pi) regardless of whether any
-  // hook-model vendors are configured. pi auto-loads `.pi/extensions/oma/`.
-  if (extensionVendors.includes("pi")) {
+  // hook-model vendors are configured. pi auto-loads `.pi/extensions/oma/` and
+  // `.pi/prompts/*.md` supplies OMA workflow slash commands.
+  const piConfigured = extensionVendors.includes("pi");
+  let piMergedDocs = false;
+  if (piConfigured) {
     installPiExtension(cwd, cwd);
+    installPiPromptTemplates(cwd, cwd);
+    if (hookVendors.length === 0) {
+      piMergedDocs = mergeRulesIndexForVendor(cwd, "pi");
+    }
     if (!quiet) {
-      console.log(`${pc.green("✓")} pi (.pi/extensions/oma/)`);
+      console.log(`${pc.green("✓")} pi (.pi/extensions/oma/, .pi/prompts/)`);
     }
   }
 
   if (hookVendors.length === 0) {
-    // Only extension vendors were configured; the bridge is installed above.
-    return empty;
+    // Only extension vendors were configured; the bridge/prompts are installed above.
+    return { ...empty, mergedDocs: piMergedDocs ? ["AGENTS.md"] : [] };
   }
 
   if (!quiet) {
@@ -403,6 +411,12 @@ export function link(opts: LinkOptions = {}): LinkResult {
     if (mergeRulesIndexForVendor(cwd, v)) {
       mergedDocsSet.add(target);
       mergedDocs.push(target);
+    }
+  }
+  if (piConfigured && !mergedDocsSet.has("AGENTS.md")) {
+    if (mergeRulesIndexForVendor(cwd, "pi")) {
+      mergedDocsSet.add("AGENTS.md");
+      mergedDocs.push("AGENTS.md");
     }
   }
 

--- a/cli/commands/update/update-cursor.test.ts
+++ b/cli/commands/update/update-cursor.test.ts
@@ -64,6 +64,7 @@ vi.mock("../../platform/skills-installer.js", () => ({
     "hermes",
     "qwen",
   ],
+  EXTENSION_VENDORS: ["pi"],
   CLI_SKILLS_DIR: {
     antigravity: {
       projectPath: ".gemini/antigravity-cli/skills",

--- a/cli/commands/update/update-global.test.ts
+++ b/cli/commands/update/update-global.test.ts
@@ -104,6 +104,7 @@ const skillsState = vi.hoisted(() => ({
     "hermes",
     "qwen",
   ],
+  EXTENSION_VENDORS: ["pi"],
   CLI_SKILLS_DIR: {
     antigravity: {
       projectPath: ".gemini/antigravity-cli/skills",

--- a/cli/commands/update/update.test.ts
+++ b/cli/commands/update/update.test.ts
@@ -187,17 +187,19 @@ describe("resolveUpdateVendors", () => {
     tempRoots.push(root);
 
     mkdirSync(join(root, ".claude"), { recursive: true });
+    mkdirSync(join(root, ".pi"), { recursive: true });
     mkdirSync(join(root, ".qwen"), { recursive: true });
 
-    expect(resolveUpdateVendors(root)).toEqual(["claude", "qwen"]);
+    expect(resolveUpdateVendors(root)).toEqual(["claude", "pi", "qwen"]);
   });
 
   it("--vendor explicitly targets vendors even when directories do not exist", () => {
     const root = mkdtempSync(join(tmpdir(), "oma-update-vendors-"));
     tempRoots.push(root);
 
-    expect(resolveUpdateVendors(root, { vendor: "claude,qwen" })).toEqual([
+    expect(resolveUpdateVendors(root, { vendor: "claude,pi,qwen" })).toEqual([
       "claude",
+      "pi",
       "qwen",
     ]);
   });
@@ -211,6 +213,7 @@ describe("resolveUpdateVendors", () => {
     expect(vendors).toContain("claude");
     expect(vendors).toContain("gemini");
     expect(vendors).toContain("grok");
+    expect(vendors).toContain("pi");
     expect(vendors).toContain("qwen");
     expect(vendors).not.toContain("antigravity");
     expect(vendors).not.toContain("hermes");

--- a/cli/commands/update/update.ts
+++ b/cli/commands/update/update.ts
@@ -42,6 +42,7 @@ import {
   CLI_SKILLS_DIR,
   createVendorSymlinks,
   createVendorWorkflowSymlinks,
+  EXTENSION_VENDORS,
   getInstalledSkillNames,
   getInstalledWorkflowNames,
   REPO,
@@ -173,15 +174,18 @@ const VENDOR_ROOTS: Record<CliVendor, string[]> = {
   grok: [".grok"],
   hermes: [".hermes"],
   kiro: [".kiro"],
+  pi: [".pi"],
   qwen: [".qwen"],
 };
+
+const UPDATE_VENDORS = [...ALL_CLI_VENDORS, ...EXTENSION_VENDORS].sort();
 
 function isCliTool(vendor: CliVendor): vendor is CliTool {
   return vendor in CLI_SKILLS_DIR;
 }
 
 function parseVendorList(raw: string): CliVendor[] {
-  const validVendors = new Set<string>(ALL_CLI_VENDORS);
+  const validVendors = new Set<string>(UPDATE_VENDORS);
   const vendors = raw
     .split(",")
     .map((v) => v.trim().toLowerCase())
@@ -190,7 +194,7 @@ function parseVendorList(raw: string): CliVendor[] {
 
   if (invalid.length > 0) {
     throw new Error(
-      `Unsupported vendor(s): ${invalid.join(", ")}. Supported vendors: ${ALL_CLI_VENDORS.join(", ")}`,
+      `Unsupported vendor(s): ${invalid.join(", ")}. Supported vendors: ${UPDATE_VENDORS.join(", ")}`,
     );
   }
 
@@ -204,7 +208,7 @@ function hasExistingVendorRoot(cwd: string, vendor: CliVendor): boolean {
 }
 
 function supportedProjectVendors(): CliVendor[] {
-  return ALL_CLI_VENDORS.filter((vendor) => {
+  return UPDATE_VENDORS.filter((vendor) => {
     if (!isCliTool(vendor)) return true;
     return !vendorRequiresHomeConsent(vendor);
   });
@@ -217,7 +221,7 @@ export function resolveUpdateVendors(
   if (options.vendor) return parseVendorList(options.vendor);
   if (options.all) return supportedProjectVendors();
 
-  return ALL_CLI_VENDORS.filter((vendor) => hasExistingVendorRoot(cwd, vendor));
+  return UPDATE_VENDORS.filter((vendor) => hasExistingVendorRoot(cwd, vendor));
 }
 
 function toCliTools(vendors: CliVendor[]): CliTool[] {

--- a/cli/io/runtime-dispatch.test.ts
+++ b/cli/io/runtime-dispatch.test.ts
@@ -56,6 +56,10 @@ describe("detectRuntimeVendor", () => {
     );
   });
 
+  it("returns 'pi' when PI_CODING_AGENT=true", () => {
+    expect(detectRuntimeVendor({ PI_CODING_AGENT: "true" })).toBe("pi");
+  });
+
   it("returns 'unknown' when no known env vars are present", () => {
     expect(detectRuntimeVendor({})).toBe("unknown");
   });
@@ -549,6 +553,17 @@ describe("buildExternalInvocation — vendor branches", () => {
       "the-prompt",
     );
     expect(inv.args.at(-1)).toBe("the-prompt");
+  });
+
+  it("pi: uses -p as the prompt value flag and omits approval flags", () => {
+    const inv = buildExternalInvocation(
+      "pi",
+      { command: "pi", model_flag: "--model", default_model: "sonnet:high" },
+      "-p",
+      "the-prompt",
+    );
+    expect(inv.command).toBe("pi");
+    expect(inv.args).toEqual(["--model", "sonnet:high", "-p", "the-prompt"]);
   });
 
   it("with promptFlag → flag and prompt appended as a pair", () => {

--- a/cli/io/runtime-dispatch/detect.ts
+++ b/cli/io/runtime-dispatch/detect.ts
@@ -9,6 +9,7 @@ const SUPPORTED_RUNTIME_VENDORS = new Set<RuntimeVendor>([
   "qwen",
   "grok",
   "kiro",
+  "pi",
 ]);
 
 export function detectRuntimeVendor(
@@ -53,6 +54,10 @@ export function detectRuntimeVendor(
 
   if (env.KIRO_SESSION_ID || env.KIRO_CHAT_LOG_FILE || env.KIRO_HOME) {
     return "kiro";
+  }
+
+  if (env.PI_CODING_AGENT === "true" || env.PI_CODING_AGENT === "1") {
+    return "pi";
   }
 
   /**

--- a/cli/io/runtime-dispatch/types.ts
+++ b/cli/io/runtime-dispatch/types.ts
@@ -13,6 +13,7 @@ export type RuntimeVendor =
   | "qwen"
   | "grok"
   | "kiro"
+  | "pi"
   | "unknown";
 
 export type DispatchMode = "native" | "external";

--- a/cli/platform/pi-prompts.ts
+++ b/cli/platform/pi-prompts.ts
@@ -1,0 +1,85 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { clearNonDirectory } from "../utils/fs-utils.js";
+
+const PI_PROMPT_MARKER = "<!-- oma:generated -->";
+
+function extractWorkflowDescription(filePath: string): string | null {
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!match?.[1]) return null;
+  const descMatch = match[1].match(/^description:\s*(.+?)\s*$/m);
+  return descMatch?.[1]?.trim() ?? null;
+}
+
+function listWorkflowNames(workflowsDir: string): string[] {
+  if (!fs.existsSync(workflowsDir)) return [];
+  return fs
+    .readdirSync(workflowsDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+    .map((entry) => entry.name.slice(0, -".md".length))
+    .sort();
+}
+
+/**
+ * Generate pi prompt-template wrappers for OMA workflows.
+ *
+ * pi discovers project-local prompt templates from `.pi/prompts/*.md` and
+ * exposes them as slash commands (`/work`, `/plan`, `/review`, ...). The
+ * wrapper stays tiny and delegates to `.agents/workflows/<name>.md`, keeping
+ * `.agents/` as the source of truth.
+ */
+export function installPiPromptTemplates(
+  sourceDir: string,
+  targetDir: string,
+): string[] {
+  const workflowsDir = path.join(sourceDir, ".agents", "workflows");
+  const promptsRoot = path.join(targetDir, ".pi", "prompts");
+  const names = listWorkflowNames(workflowsDir);
+
+  if (fs.existsSync(promptsRoot)) {
+    for (const entry of fs.readdirSync(promptsRoot, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+      const promptFile = path.join(promptsRoot, entry.name);
+      let existing: string;
+      try {
+        existing = fs.readFileSync(promptFile, "utf-8");
+      } catch {
+        continue;
+      }
+      if (!existing.includes(PI_PROMPT_MARKER)) continue;
+      const name = entry.name.slice(0, -".md".length);
+      if (!names.includes(name)) {
+        fs.rmSync(promptFile, { force: true });
+      }
+    }
+  }
+
+  if (names.length === 0) return [];
+
+  clearNonDirectory(promptsRoot);
+  fs.mkdirSync(promptsRoot, { recursive: true });
+
+  const written: string[] = [];
+  for (const name of names) {
+    const description =
+      extractWorkflowDescription(path.join(workflowsDir, `${name}.md`)) ??
+      `Workflow: ${name}`;
+    const promptFile = path.join(promptsRoot, `${name}.md`);
+    if (fs.existsSync(promptFile)) {
+      if (!fs.statSync(promptFile).isFile()) continue;
+      const existing = fs.readFileSync(promptFile, "utf-8");
+      if (!existing.includes(PI_PROMPT_MARKER)) continue;
+    }
+    const body = `---\ndescription: ${description}\n---\n${PI_PROMPT_MARKER}\n\nRead and follow \`.agents/workflows/${name}.md\` step by step.\n\nUser request:\n$ARGUMENTS\n`;
+    fs.writeFileSync(promptFile, body);
+    written.push(path.relative(targetDir, promptFile));
+  }
+
+  return written;
+}

--- a/cli/platform/rules.ts
+++ b/cli/platform/rules.ts
@@ -156,6 +156,7 @@ const VENDOR_FILES: Record<string, string> = {
   codex: "AGENTS.md",
   cursor: "AGENTS.md",
   qwen: "AGENTS.md",
+  pi: "AGENTS.md",
 };
 
 /** Vendor-specific subagent spawn instructions. */
@@ -168,6 +169,7 @@ const VENDOR_SPAWN: Record<string, string> = {
   codex:
     "Same-vendor native dispatch via Codex custom agents in `.codex/agents/{name}.toml`; cross-vendor fallback via `oma agent:spawn`",
   qwen: "`oma agent:spawn {agent} {prompt} {sessionId}`",
+  pi: "pi has no native subagent API; use `oma agent:spawn {agent} {prompt} {sessionId} -m pi` for CLI subprocess dispatch",
 };
 
 /** Vendor-specific hook info. */
@@ -181,6 +183,7 @@ const VENDOR_HOOKS: Record<string, string> = {
   cursor:
     "Hooks: `UserPromptSubmit` / `beforeSubmitPrompt` (keyword detection)",
   qwen: "Hooks: `UserPromptSubmit` (keyword detection), `PreToolUse`, `Stop` (persistent mode)",
+  pi: "Extension bridge: `.pi/extensions/oma/index.ts` maps `before_agent_start` and `tool_call` to OMA hook scripts",
 };
 
 /**

--- a/cli/types/vendors.ts
+++ b/cli/types/vendors.ts
@@ -1,4 +1,4 @@
-import type { VENDORS } from "../constants/vendors.js";
+import type { EXTENSION_VENDORS, VENDORS } from "../constants/vendors.js";
 
 /**
  * Canonical vendor type, derived from the `VENDORS` runtime constant in
@@ -7,6 +7,7 @@ import type { VENDORS } from "../constants/vendors.js";
  * for the inclusion rationale (especially the cursor partial-support note).
  */
 export type VendorType = (typeof VENDORS)[number];
+export type ExtensionVendorType = (typeof EXTENSION_VENDORS)[number];
 
 /** CLI tools that support skill symlinking. */
 export const CLI_TOOLS = [
@@ -22,8 +23,8 @@ export const CLI_TOOLS = [
 ] as const;
 export type CliTool = (typeof CLI_TOOLS)[number];
 
-/** All CLI tools including non-hook vendors. */
-export type CliVendor = VendorType | "copilot" | "hermes";
+/** All CLI tools including non-hook and extension-model vendors. */
+export type CliVendor = VendorType | ExtensionVendorType | "copilot" | "hermes";
 
 export interface CLICheck {
   name: string;

--- a/docs/SUPPORTED_AGENTS.md
+++ b/docs/SUPPORTED_AGENTS.md
@@ -17,6 +17,7 @@ The installer can then project compatibility to other tool-specific directories 
 | Cursor | `.cursor/skills/` + `.cursor/rules/*.mdc` | First-class | Native + Adapter | `oma install` / `oma link cursor` materializes skills, rules, MCP symlink, and AGENTS.md from `.agents/`; `cursor-agent` is dispatched natively via the `cursor` preset |
 | GitHub Copilot | `.github/skills/` | Supported | Optional symlink | Created when selected during install |
 | Grok | `.agents/skills/` (direct) + `.grok/hooks/` + `.grok/agents/` | Native + Hooks + Agents | Supported (hooks + agent variant) |
+| pi | `.agents/skills/` + `.pi/prompts/` + `.pi/extensions/oma/` | Supported | Native skills + Extension bridge | Pi loads OMA skills directly, workflow prompts via `.pi/prompts`, and keyword/test hooks through a TypeScript extension bridge. |
 
 ## Vendor Adaptation
 
@@ -31,6 +32,7 @@ Abstract agent definitions in `.agents/agents/` are vendor-neutral (name, descri
 | Gemini CLI | `.gemini/agents/*.md` | Markdown | Native |
 | Antigravity | (reads `.agents/agents/` directly) | YAML | Not supported (no custom subagents) |
 | Grok | `.grok/agents/` (generated) + `.grok/hooks/` | Markdown + JSON | Supported via variant |
+| pi | `.pi/prompts/*.md` + `.pi/extensions/oma/` | Prompt templates + TypeScript extension | External via `oma agent:spawn -m pi` |
 
 ## What “First-class” Means
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,14 @@
   "engines": {
     "node": ">=24.0"
   },
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "skills": [
+      ".agents/skills"
+    ]
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",
     "@commitlint/cli": "20.4.3",


### PR DESCRIPTION
## 요약

- `oma link pi`가 `.pi/extensions/oma/`와 `.pi/prompts/*.md`를 생성하도록 연결했습니다.
- Pi 런타임 감지(`PI_CODING_AGENT=true|1`)와 `oma agent:spawn ... -m pi` 외부 실행 경로를 추가했습니다.
- Pi용 실행 프로토콜/문서/테스트를 추가했습니다.
- 최신 `main` 기준으로 rebase했고, web tsconfig 변경 커밋은 제거했습니다.

## 상세

- Pi는 기존 hook vendor가 아니라 extension vendor로 유지했습니다.
  - `.pi/extensions/oma/index.ts` extension bridge 사용
  - OMA workflow는 `.pi/prompts/*.md` prompt template로 노출
- `oma update`가 기존 `.pi/` 설치를 감지해 Pi 산출물을 갱신하도록 했습니다.
- 사용자 작성 `.pi/prompts/*.md`는 덮어쓰지 않도록 `<!-- oma:generated -->` marker가 있는 파일만 갱신합니다.
- 루트 `package.json`에는 Pi package discoverability용 `pi-package` keyword와 skills 경로만 추가했습니다.

## 검증

- `cli/node_modules/.bin/tsc --noEmit -p tsconfig.json`
- `web/node_modules/.bin/tsc --noEmit -p web/tsconfig.json`
- `bun run --cwd cli lint`
- `bun run --cwd cli test -- commands/link/__tests__/link.test.ts commands/update/update.test.ts __tests__/pi-extension.test.ts io/runtime-dispatch.test.ts`
- `~/oma-pi-test`에서 실제 Pi 연동 확인
  - `.pi/extensions/oma/index.ts` 생성 확인
  - `.pi/prompts/work.md` 생성 확인
  - Pi RPC `get_commands`에서 `/work`, `/plan`, `/review`, `skill:oma-backend` 확인
  - fake `pi`로 `oma agent:spawn backend ... -m pi`가 `pi --model sonnet:high -p ...` 형태로 호출되는지 확인

## PR 템플릿

- 저장소에 PR 템플릿이 없어 위 형식으로 작성했습니다.
