### PR TITLE
fix(install): reclaim a crashed install/update lock in 60s, not 10min

### DIFF
--- a/cli/commands/install/install.ts
+++ b/cli/commands/install/install.ts
@@ -59,6 +59,8 @@ import { isTelemetryEnabled } from "../../utils/config.js";
 import {
   acquireLock,
   bindInstallLockRelease,
+  DEAD_PID_GRACE_MS,
+  lockPath,
 } from "../../utils/install-lock.js";
 import { link } from "../link/link.js";
 import { runMigrations } from "../migrations/index.js";
@@ -258,7 +260,7 @@ export async function install(options: InstallOptions = {}): Promise<void> {
   const lockResult = acquireLock(installRoot);
   if (!lockResult.ok) {
     p.cancel(
-      `Another oma install/update is running (pid=${lockResult.held.pid}). Try again in a moment.`,
+      `Another oma install/update is running (pid=${lockResult.held.pid}). If none is running it crashed — remove ${lockPath(installRoot)}, or wait ~${DEAD_PID_GRACE_MS / 1000}s for it to auto-clear.`,
     );
     process.exit(1);
   }

--- a/cli/commands/update/update.ts
+++ b/cli/commands/update/update.ts
@@ -63,6 +63,8 @@ import { t } from "../../utils/i18n.js";
 import {
   acquireLock,
   bindInstallLockRelease,
+  DEAD_PID_GRACE_MS,
+  lockPath,
 } from "../../utils/install-lock.js";
 import { link } from "../link/link.js";
 import { runMigrations } from "../migrations/index.js";
@@ -249,7 +251,11 @@ export async function update(options: UpdateOptions = {}): Promise<void> {
   // Acquire install lock — prevents concurrent install/update runs
   const lock = acquireLock(installRoot);
   if (!lock.ok) {
-    const msg = t("install.lockHeld", { pid: lock.held.pid });
+    const msg = t("install.lockHeld", {
+      pid: lock.held.pid,
+      path: lockPath(installRoot),
+      grace: DEAD_PID_GRACE_MS / 1000,
+    });
     if (ci) {
       throw new Error(msg);
     }

--- a/cli/utils/i18n.test.ts
+++ b/cli/utils/i18n.test.ts
@@ -62,16 +62,26 @@ describe("t()", () => {
 
   it("interpolates {pid} correctly", () => {
     process.env.LANG = "en_US.UTF-8";
-    const result = t("install.lockHeld", { pid: 12345 });
+    const result = t("install.lockHeld", {
+      pid: 12345,
+      path: "/x/.agents/_install.lock",
+      grace: 60,
+    });
     expect(result).toContain("12345");
     expect(result).not.toContain("{pid}");
+    expect(result).not.toContain("{path}");
   });
 
   it("interpolates {pid} correctly in Korean", () => {
     process.env.LANG = "ko_KR.UTF-8";
-    const result = t("install.lockHeld", { pid: 9999 });
+    const result = t("install.lockHeld", {
+      pid: 9999,
+      path: "/x/.agents/_install.lock",
+      grace: 60,
+    });
     expect(result).toContain("9999");
     expect(result).not.toContain("{pid}");
+    expect(result).not.toContain("{path}");
   });
 
   it("returns message without interpolation when no vars passed", () => {

--- a/cli/utils/i18n.ts
+++ b/cli/utils/i18n.ts
@@ -33,8 +33,8 @@ export const MESSAGES: Catalog = {
     ko: "oh-my-agent를 글로벌로 처음 설치합니다.",
   },
   "install.lockHeld": {
-    en: "Another oma install/update is running (pid={pid}). Try again in a moment.",
-    ko: "다른 oma install/update가 실행 중입니다 (pid={pid}). 잠시 후 다시 시도하세요.",
+    en: "Another oma install/update is running (pid={pid}). If none is running it crashed — remove {path}, or wait ~{grace}s for it to auto-clear.",
+    ko: "다른 oma install/update가 실행 중입니다 (pid={pid}). 실행 중이 아니면 비정상 종료된 것입니다 — {path}를 삭제하거나 ~{grace}초 후 자동 해제를 기다리세요.",
   },
   "install.outroSuccess": {
     en: "Done! Next steps:\n  1. Open your project in your IDE\n  2. Type /orchestrate to spawn a multi-agent workflow\n  3. Run `oma doctor` if anything looks off",

--- a/cli/utils/install-lock.test.ts
+++ b/cli/utils/install-lock.test.ts
@@ -12,6 +12,7 @@ import {
   _forceReleaseLock,
   acquireLock,
   bindInstallLockRelease,
+  DEAD_PID_GRACE_MS,
   lockPath,
 } from "./install-lock.js";
 
@@ -69,30 +70,56 @@ describe("acquireLock", () => {
     }
   });
 
-  it("auto-clears a stale lock when pid is dead and time > STALE_AFTER_MS", () => {
+  it("auto-clears a dead-pid lock older than the grace window", () => {
     const root = mkdtempSync(join(tmpdir(), "oma-lock-"));
     tempRoots.push(root);
 
-    // Write a stale lock: pid that is definitely dead (very high number unlikely to exist)
-    // and a startedAt well past the 10-minute threshold
-    const deadPid = 9999999; // extremely unlikely to exist
-    const staleTime = new Date(Date.now() - 11 * 60 * 1000).toISOString(); // 11 minutes ago
+    // pid that is definitely dead (very high number unlikely to exist), with a
+    // startedAt past DEAD_PID_GRACE_MS — should be reclaimed.
+    const deadPid = 9999999;
+    const pastGrace = new Date(
+      Date.now() - (DEAD_PID_GRACE_MS + 5000),
+    ).toISOString();
     mkdirSync(join(root, ".agents"), { recursive: true });
     writeFileSync(
       lockPath(root),
       JSON.stringify({
         pid: deadPid,
         hostname: hostname(),
-        startedAt: staleTime,
+        startedAt: pastGrace,
         uid: 0,
       }),
     );
 
     const result = acquireLock(root);
-    // Should have auto-cleared and successfully acquired
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      result.release();
+    if (result.ok) result.release();
+  });
+
+  it("does NOT clear a dead-pid lock still within the grace window", () => {
+    const root = mkdtempSync(join(tmpdir(), "oma-lock-"));
+    tempRoots.push(root);
+
+    // Dead pid, but the lock was created just now: a SIGKILLed install/update may
+    // have orphaned child processes still finishing, so the short grace must hold.
+    const deadPid = 9999999;
+    const withinGrace = new Date(Date.now() - 5000).toISOString();
+    mkdirSync(join(root, ".agents"), { recursive: true });
+    writeFileSync(
+      lockPath(root),
+      JSON.stringify({
+        pid: deadPid,
+        hostname: hostname(),
+        startedAt: withinGrace,
+        uid: 0,
+      }),
+    );
+
+    const result = acquireLock(root);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("active");
+      expect(result.held.pid).toBe(deadPid);
     }
   });
 

--- a/cli/utils/install-lock.ts
+++ b/cli/utils/install-lock.ts
@@ -22,7 +22,16 @@ export type AcquireResult =
   | { ok: true; release: () => void }
   | { ok: false; held: LockMeta; reason: "active" | "stale-but-uncleared" };
 
-const STALE_AFTER_MS = 10 * 60 * 1000; // 10 minutes
+/**
+ * Once the lock's recorded pid is confirmed DEAD on this host (ESRCH), wait this
+ * short grace before reclaiming it. The grace exists only to let an orphaned
+ * child subprocess of a SIGKILLed install/update (npm/git/file copy) finish —
+ * the lock guards fast, synchronous reconciliation, so a long wait is
+ * unnecessary and would block the next install for no reason after a crash. An
+ * ambiguous (EPERM "exists but can't signal") pid is treated as alive and never
+ * reclaimed, regardless of this grace.
+ */
+export const DEAD_PID_GRACE_MS = 60_000; // 60 seconds
 
 /** Lock path: <installRoot>/.agents/_install.lock (transient runtime lock) */
 export function lockPath(installRoot: string): string {
@@ -88,7 +97,12 @@ function readLockFile(path: string): LockMeta | null {
   }
 }
 
-/** Try to acquire the install lock. Atomic via O_EXCL; auto-clears stale locks where pid is dead. */
+/**
+ * Try to acquire the install lock (atomic via O_EXCL). An existing lock is
+ * reclaimed only when its recorded pid is confirmed dead on THIS host and the
+ * lock is older than DEAD_PID_GRACE_MS. A live pid, an ambiguous (EPERM) pid,
+ * or a foreign hostname is never auto-cleared.
+ */
 export function acquireLock(installRoot: string): AcquireResult {
   const path = lockPath(installRoot);
 
@@ -131,7 +145,7 @@ export function acquireLock(installRoot: string): AcquireResult {
 
       const pidAlive = isPidAlive(existing.pid);
       const ageMs = Date.now() - new Date(existing.startedAt).getTime();
-      const isStale = !pidAlive && ageMs > STALE_AFTER_MS;
+      const isStale = !pidAlive && ageMs > DEAD_PID_GRACE_MS;
 
       if (isStale) {
         // Auto-clear stale lock and retry once


### PR DESCRIPTION
## Problem
A user hit this on a fresh terminal and could not run `oma install` for ~10 minutes:

```
└  Another oma install/update is running (pid=24891). Try again in a moment.
```

`pid=24891` was **already dead** (`process.kill(24891, 0)` → ESRCH), yet the lock was not reclaimed.

## Root cause
`oma install` / `oma update` hold `<root>/.agents/_install.lock` for the duration of their work and release it in a `finally` block + on `SIGINT`/`SIGTERM` (`bindInstallLockRelease`). **None of those fire on `SIGKILL`** (e.g. the background auto-update getting force-killed when its session ends), so the lock file leaks.

The reclaim logic then required **both** a dead pid **and** the lock being older than `STALE_AFTER_MS` = **10 minutes**:

```ts
const isStale = !pidAlive && ageMs > STALE_AFTER_MS; // 10 min
```

So a crashed run blocked the next install/update for up to 10 minutes — even though the holder was confirmed dead. The docstring ("auto-clears stale locks where pid is dead") was also misleading: it understated the 10-minute requirement.

## Fix
Reclaim a **confirmed-dead (ESRCH), same-host** lock after a **60s grace** (`DEAD_PID_GRACE_MS`) instead of 10 minutes. The grace only needs to outlast any orphaned child subprocess of a SIGKILLed run; the install lock guards fast, synchronous file/symlink reconciliation (the heavy `oma video doctor` provisioning is separate), so a long wait is unnecessary.

Unchanged safety: a live pid, an **ambiguous (EPERM)** pid, or a **foreign hostname** is still never auto-cleared.

Also surfaces the lock path + auto-clear window in the lock-held message (install + update, en/ko) so a stuck user knows exactly what to remove:

> Another oma install/update is running (pid=N). If none is running it crashed — remove `<root>/.agents/_install.lock`, or wait ~60s for it to auto-clear.

## Tests
- New: dead-pid lock **past** the grace → reclaimed; dead-pid lock **within** the grace → held (orphan safety).
- Existing host/active/idempotency/signal tests unchanged.
- `tsc` clean, full suite **2586 pass / 0 fail**, lint clean.

🤖 Generated with [Claude Code](https://claude.ai/code)
