### PR TITLE
chore: add npm source metadata

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -107,6 +107,10 @@
     "type": "git",
     "url": "https://github.com/first-fluke/oh-my-agent"
   },
+  "homepage": "https://github.com/first-fluke/oh-my-agent#readme",
+  "bugs": {
+    "url": "https://github.com/first-fluke/oh-my-agent/issues"
+  },
   "antigravity": {
     "skillsPath": ".agents/skills",
     "skills": [


### PR DESCRIPTION
Summary:
- Add homepage and bugs metadata to the published oh-my-agent package manifest.

Validation:
- node package metadata assertion
- npm pack --dry-run --json --ignore-scripts in cli
- git diff --check