### PR TITLE
chore: add npm metadata links

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -107,6 +107,10 @@
     "type": "git",
     "url": "https://github.com/first-fluke/oh-my-agent"
   },
+  "homepage": "https://github.com/first-fluke/oh-my-agent#readme",
+  "bugs": {
+    "url": "https://github.com/first-fluke/oh-my-agent/issues"
+  },
   "antigravity": {
     "skillsPath": ".agents/skills",
     "skills": [


### PR DESCRIPTION
## Summary
- add homepage metadata pointing to the repository README
- add bugs.url metadata pointing to the GitHub issue tracker

## Validation
- parsed cli/package.json with Node JSON.parse
- git diff --check