### PR TITLE
fix(ci): restore stargazers daily API access

### DIFF
--- a/.github/workflows/stargazers-daily.yml
+++ b/.github/workflows/stargazers-daily.yml
@@ -20,7 +20,8 @@ jobs:
 
       - name: Track stargazers on orphan branch
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Stargazer listings require an admin/collaborator identity since 2026-07-14.
+          GH_TOKEN: ${{ secrets.ACTION_SYNC_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/cli/__tests__/stargazers-workflow.test.ts
+++ b/cli/__tests__/stargazers-workflow.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+
+const PROJECT_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+describe("Stargazers Daily workflow", () => {
+  it("uses a collaborator token for the restricted stargazer listing API", () => {
+    const workflow = parseYaml(
+      readFileSync(
+        resolve(PROJECT_ROOT, ".github/workflows/stargazers-daily.yml"),
+        "utf8",
+      ),
+    ) as {
+      jobs: {
+        track: {
+          permissions: Record<string, string>;
+          steps: Array<{ name?: string; env?: Record<string, string> }>;
+        };
+      };
+    };
+
+    const track = workflow.jobs.track;
+    const tracker = track.steps.find(
+      (step) => step.name === "Track stargazers on orphan branch",
+    );
+
+    expect(tracker?.env?.GH_TOKEN).toBe(
+      "$" + "{{ secrets.ACTION_SYNC_TOKEN }}",
+    );
+    expect(track.permissions).toEqual({ contents: "write" });
+  });
+});


### PR DESCRIPTION
## Summary

- use the collaborator-backed `ACTION_SYNC_TOKEN` for GitHub's restricted stargazer listing endpoint
- add regression coverage for the workflow credential route and permissions
- rotate the expired repository secret without exposing its value

## Root cause

GitHub restricted stargazer listings to admins and collaborators on 2026-07-14. The ephemeral `GITHUB_TOKEN` began returning HTTP 403, and the existing `ACTION_SYNC_TOKEN` had expired and returned HTTP 401.

## Verification

- regression test fails with `secrets.GITHUB_TOKEN` and passes with `secrets.ACTION_SYNC_TOKEN`
- lint and root typecheck pass
- full CLI suite: 3,865 passed; 4 skipped; 1 todo
- live workflow dispatch passed: https://github.com/first-fluke/oh-my-agent/actions/runs/29628886271