### PR TITLE
feat(codex): route custom agents to terra and luna

### DIFF
--- a/.agents/agents/variants/agent-variant.schema.json
+++ b/.agents/agents/variants/agent-variant.schema.json
@@ -27,6 +27,11 @@
       "type": "string",
       "description": "The default AI model to use for this vendor's agents"
     },
+    "effortDefault": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "xhigh", "max", "ultra"],
+      "description": "The default reasoning effort for this vendor's agents"
+    },
     "maxTurnsDefault": {
       "type": "integer",
       "description": "The default maximum number of turns allowed for agents"
@@ -72,7 +77,7 @@
           },
           "effort": {
             "type": "string",
-            "enum": ["low", "medium", "high"]
+            "enum": ["low", "medium", "high", "xhigh", "max", "ultra"]
           },
           "extra": {
             "type": "object",

--- a/.agents/agents/variants/codex.json
+++ b/.agents/agents/variants/codex.json
@@ -2,7 +2,8 @@
   "$schema": "./agent-variant.schema.json",
   "vendor": "codex",
   "destDir": ".codex/agents",
-  "modelDefault": "gpt-5.4",
+  "modelDefault": "gpt-5.6-terra",
+  "effortDefault": "high",
   "toolsDefault": [],
   "protocolPath": ".agents/skills/_shared/runtime/execution-protocols/codex.md",
   "agents": {
@@ -17,7 +18,6 @@
       }
     },
     "db-engineer": {
-      "effort": "medium",
       "extra": {
         "sandbox_mode": "workspace-write"
       }
@@ -35,7 +35,6 @@
       }
     },
     "tf-infra-engineer": {
-      "effort": "medium",
       "extra": {
         "sandbox_mode": "workspace-write"
       }
@@ -46,7 +45,6 @@
       }
     },
     "pm-planner": {
-      "effort": "medium",
       "extra": {
         "sandbox_mode": "read-only"
       }
@@ -58,9 +56,17 @@
       }
     },
     "docs-curator": {
-      "effort": "medium",
+      "model": "gpt-5.6-luna",
+      "effort": "max",
       "extra": {
         "sandbox_mode": "workspace-write"
+      }
+    },
+    "research-explorer": {
+      "model": "gpt-5.6-luna",
+      "effort": "max",
+      "extra": {
+        "sandbox_mode": "read-only"
       }
     }
   }

--- a/cli/platform/agent-composer.test.ts
+++ b/cli/platform/agent-composer.test.ts
@@ -8,6 +8,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   installVendorAgents,
@@ -474,6 +475,37 @@ describe("installVendorAgents — protocolPath validation", () => {
       expect(existsSync(join(targetDir, ".claude", "agents"))).toBe(false);
     } finally {
       warn.mockRestore();
+    }
+  });
+});
+
+describe("installVendorAgents — real Codex variant SSOT", () => {
+  it("generates Terra/high defaults and Luna/max fast-role overrides", () => {
+    const sourceDir = fileURLToPath(new URL("../..", import.meta.url));
+    const targetDir = mkdtempSync(join(tmpdir(), "oma-codex-agent-dst-"));
+
+    try {
+      expect(
+        installVendorAgents(sourceDir, targetDir, "codex"),
+      ).toBeGreaterThan(0);
+
+      const backend = readFileSync(
+        join(targetDir, ".codex", "agents", "backend-engineer.toml"),
+        "utf-8",
+      );
+      expect(backend).toContain('model = "gpt-5.6-terra"');
+      expect(backend).toContain('model_reasoning_effort = "high"');
+
+      for (const agent of ["docs-curator", "research-explorer"]) {
+        const content = readFileSync(
+          join(targetDir, ".codex", "agents", `${agent}.toml`),
+          "utf-8",
+        );
+        expect(content).toContain('model = "gpt-5.6-luna"');
+        expect(content).toContain('model_reasoning_effort = "max"');
+      }
+    } finally {
+      rmSync(targetDir, { recursive: true, force: true });
     }
   });
 });

--- a/cli/platform/agent-composer.ts
+++ b/cli/platform/agent-composer.ts
@@ -61,6 +61,7 @@ export interface AgentVariant {
   vendor: string;
   destDir: string;
   modelDefault: string;
+  effortDefault?: string;
   maxTurnsDefault?: number;
   toolsDefault: string[] | string;
   protocolPath: string;
@@ -264,7 +265,7 @@ function buildCodexAgentFile(
   const model = String(
     config.model || frontmatter.model || variant.modelDefault,
   );
-  const reasoningEffort = config.effort || "medium";
+  const reasoningEffort = config.effort || variant.effortDefault || "medium";
   const sandboxMode =
     typeof config.extra?.sandbox_mode === "string"
       ? config.extra.sandbox_mode

--- a/cli/platform/skills-installer.test.ts
+++ b/cli/platform/skills-installer.test.ts
@@ -372,7 +372,8 @@ describe("installVendorAdaptations", () => {
           return JSON.stringify({
             vendor: "codex",
             destDir: ".codex/agents",
-            modelDefault: "gpt-5.4",
+            modelDefault: "gpt-5.6-terra",
+            effortDefault: "high",
             toolsDefault: [],
             protocolPath:
               ".agents/skills/_shared/runtime/execution-protocols/codex.md",
@@ -432,6 +433,14 @@ describe("installVendorAdaptations", () => {
     expectAtomicWrite(
       join(mockTargetDir, ".codex", "agents", "tf-infra-engineer.toml"),
       expect.stringContaining("execution-protocols/codex.md"),
+    );
+    expectAtomicWrite(
+      join(mockTargetDir, ".codex", "agents", "tf-infra-engineer.toml"),
+      expect.stringContaining('model = "gpt-5.6-terra"'),
+    );
+    expectAtomicWrite(
+      join(mockTargetDir, ".codex", "agents", "tf-infra-engineer.toml"),
+      expect.stringContaining('model_reasoning_effort = "high"'),
     );
   });
 });

--- a/com.firstfluke.oma/agents/variants/agent-variant.schema.json
+++ b/com.firstfluke.oma/agents/variants/agent-variant.schema.json
@@ -27,6 +27,11 @@
       "type": "string",
       "description": "The default AI model to use for this vendor's agents"
     },
+    "effortDefault": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "xhigh", "max", "ultra"],
+      "description": "The default reasoning effort for this vendor's agents"
+    },
     "maxTurnsDefault": {
       "type": "integer",
       "description": "The default maximum number of turns allowed for agents"
@@ -72,7 +77,7 @@
           },
           "effort": {
             "type": "string",
-            "enum": ["low", "medium", "high"]
+            "enum": ["low", "medium", "high", "xhigh", "max", "ultra"]
           },
           "extra": {
             "type": "object",

--- a/com.firstfluke.oma/agents/variants/codex.json
+++ b/com.firstfluke.oma/agents/variants/codex.json
@@ -2,7 +2,8 @@
   "$schema": "./agent-variant.schema.json",
   "vendor": "codex",
   "destDir": ".codex/agents",
-  "modelDefault": "gpt-5.4",
+  "modelDefault": "gpt-5.6-terra",
+  "effortDefault": "high",
   "toolsDefault": [],
   "protocolPath": ".agents/skills/_shared/runtime/execution-protocols/codex.md",
   "agents": {
@@ -17,7 +18,6 @@
       }
     },
     "db-engineer": {
-      "effort": "medium",
       "extra": {
         "sandbox_mode": "workspace-write"
       }
@@ -35,7 +35,6 @@
       }
     },
     "tf-infra-engineer": {
-      "effort": "medium",
       "extra": {
         "sandbox_mode": "workspace-write"
       }
@@ -46,7 +45,6 @@
       }
     },
     "pm-planner": {
-      "effort": "medium",
       "extra": {
         "sandbox_mode": "read-only"
       }
@@ -58,9 +56,17 @@
       }
     },
     "docs-curator": {
-      "effort": "medium",
+      "model": "gpt-5.6-luna",
+      "effort": "max",
       "extra": {
         "sandbox_mode": "workspace-write"
+      }
+    },
+    "research-explorer": {
+      "model": "gpt-5.6-luna",
+      "effort": "max",
+      "extra": {
+        "sandbox_mode": "read-only"
       }
     }
   }


### PR DESCRIPTION
## Summary

- default generated Codex agents to gpt-5.6-terra with high reasoning
- route documentation and research roles to gpt-5.6-luna with max reasoning
- add effortDefault schema support and regression coverage

## Validation

- lint passed
- typecheck passed
- 313 test files passed (4,226 tests)
- emit-drift check passed

No build was run.