### PR TITLE
feat(model): add OrcaRouter as a named gateway provider

### DIFF
--- a/cli/io/runtime-dispatch/pi-model-map.test.ts
+++ b/cli/io/runtime-dispatch/pi-model-map.test.ts
@@ -14,6 +14,11 @@ describe("toPiModel", () => {
     );
   });
 
+  it("passes orcarouter gateway slugs through unchanged", () => {
+    expect(toPiModel("orcarouter/auto")).toBe("orcarouter/auto");
+    expect(toPiModel("orcarouter/fusion")).toBe("orcarouter/fusion");
+  });
+
   it("passes a bare id (no owner) through for fuzzy matching", () => {
     expect(toPiModel("claude-sonnet-4-6")).toBe("claude-sonnet-4-6");
   });

--- a/cli/io/runtime-dispatch/pi-model-map.ts
+++ b/cli/io/runtime-dispatch/pi-model-map.ts
@@ -7,8 +7,17 @@ import type { AgentPlan } from "./types.js";
  * genuine provider are dispatchable. CLI-proprietary owners (cursor, kiro,
  * qwen, antigravity) name models that exist only inside their own CLIs and
  * cannot be addressed through pi's `--model`.
+ *
+ * `orcarouter` (https://www.orcarouter.ai) is an OpenAI-compatible gateway
+ * proxy — like anthropic/openai/google it is a real LLM provider pi can route
+ * to via BYOK, not a CLI-proprietary owner.
  */
-const PI_RUNNABLE_PROVIDERS = new Set(["anthropic", "openai", "google"]);
+const PI_RUNNABLE_PROVIDERS = new Set([
+  "anthropic",
+  "openai",
+  "google",
+  "orcarouter",
+]);
 
 /**
  * Translate an oma registry slug (`owner/slug`) into pi's `--model` argument

--- a/cli/platform/model-registry.test.ts
+++ b/cli/platform/model-registry.test.ts
@@ -448,6 +448,19 @@ describe("buildUnknownSlugError", () => {
     expect(msg).toContain("cli_model: gpt-99-future");
   });
 
+  it("scaffolds an OrcaRouter gateway model via the opencode CLI", async () => {
+    const { buildUnknownSlugError } = await import("./model-registry.js");
+    const msg = buildUnknownSlugError("orcarouter/auto", "pm");
+    expect(msg).toContain('Unknown model slug "orcarouter/auto"');
+    expect(msg).toContain('for agent "pm"');
+    expect(msg).toContain("OrcaRouter");
+    expect(msg).toContain("orcarouter (CLI: opencode)");
+    expect(msg).toMatch(/models:\n\s+orcarouter\/auto:/);
+    expect(msg).toContain("cli: opencode");
+    expect(msg).toContain("native_dispatch_from: [opencode]");
+    expect(msg).toContain("https://api.orcarouter.ai/v1/models");
+  });
+
   it("scaffolds for qwen pairing", async () => {
     const { buildUnknownSlugError } = await import("./model-registry.js");
     const msg = buildUnknownSlugError("qwen/qwen99-plus");

--- a/cli/platform/model-registry.ts
+++ b/cli/platform/model-registry.ts
@@ -165,6 +165,11 @@ export const OWNER_TO_CLI: Record<string, RuntimeId> = {
   qwen: "qwen",
   kiro: "kiro",
   opencode: "opencode",
+  // OrcaRouter (https://www.orcarouter.ai) is an OpenAI-compatible gateway
+  // that exposes its own catalog (`orcarouter/*` aliases plus vendor-qualified
+  // models). Unregistered `orcarouter/*` slugs dispatch through the opencode
+  // CLI, mirroring the `opencode-*` provider-tier rule below.
+  orcarouter: "opencode",
 };
 
 /**
@@ -210,6 +215,37 @@ export function buildUnknownSlugError(slug: string, agentId?: string): string {
 
   if (cli && cliModel) {
     const builtIn = listBuiltInSlugsByOwner(owner);
+    // Gateway owners (OpenRouter / OrcaRouter) resolve to a CLI but expose
+    // their own catalog — tailor the hint so the user is pointed at the right
+    // gateway rather than a vendor-native model.
+    if (owner === "orcarouter") {
+      lines.push(
+        `This looks like an OrcaRouter model for ${owner} (CLI: ${cli}).`,
+        `OrcaRouter (https://www.orcarouter.ai) is an OpenAI-compatible gateway — its ` +
+          `\`orcarouter/*\` aliases and vendor-qualified models dispatch through the ` +
+          `${cli} CLI. Register it in .agents/oma-config.yaml:`,
+        "",
+        "models:",
+        `  ${slug}:`,
+        `    cli: ${cli}`,
+        `    cli_model: ${cliModel}            # confirm via \`${cli} --help\``,
+        "    supports:",
+        `      native_dispatch_from: [${cli}]`,
+        "",
+      );
+      if (builtIn.length > 0) {
+        lines.push(
+          `Built-in ${owner} slugs you can use without a models: block:`,
+          ...builtIn.map((s) => `  - ${s}`),
+          "",
+        );
+      }
+      lines.push(
+        "Browse OrcaRouter models: https://api.orcarouter.ai/v1/models",
+      );
+      return lines.join("\n");
+    }
+
     lines.push(
       `This looks like an OpenRouter slug for ${owner} (CLI: ${cli}).`,
       `If your ${cli} CLI accepts this model, register it in .agents/oma-config.yaml:`,

--- a/cli/vendors/pi/auth.test.ts
+++ b/cli/vendors/pi/auth.test.ts
@@ -34,6 +34,9 @@ describe("isPiAuthenticated", () => {
     expect(isPiAuthenticated(isolatedEnv({ GEMINI_API_KEY: "g-x" }))).toBe(
       true,
     );
+    expect(
+      isPiAuthenticated(isolatedEnv({ ORCAROUTER_API_KEY: "sk-orca-x" })),
+    ).toBe(true);
   });
 
   it("ignores blank/whitespace-only API keys", () => {

--- a/cli/vendors/pi/auth.ts
+++ b/cli/vendors/pi/auth.ts
@@ -16,6 +16,7 @@ const PI_PROVIDER_ENV_KEYS = [
   "XAI_API_KEY",
   "MISTRAL_API_KEY",
   "AZURE_OPENAI_API_KEY",
+  "ORCAROUTER_API_KEY",
 ] as const;
 
 /**

--- a/web/docs/guide/per-agent-models.md
+++ b/web/docs/guide/per-agent-models.md
@@ -484,3 +484,71 @@ Each routed agent dispatches `kimi --model kimi-code/kimi-for-coding -p "<prompt
 > 2 / stderr, but the `oma hook` router always exits 0 and emits a stdout dialect.
 > oma emits a best-effort `permissionDecision: "deny"` (plus Claude-style
 > `decision: "block"`) so persistent workflows degrade gracefully under Kimi.
+
+---
+
+## Dispatching through OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway that
+routes to 200+ models under one key (`sk-orca-…`). It exposes its own gateway
+aliases (`orcarouter/auto`, `orcarouter/fusion`, …) alongside vendor-qualified
+models (`anthropic/*`, `openai/*`, `deepseek/*`, …), so oma treats it as a
+real-provider owner: `orcarouter/*` slugs dispatch through the **opencode** CLI
+and can route through the **pi** BYOK transport, exactly like anthropic/openai.
+
+### Explicit dispatch
+
+Route any agent through OrcaRouter with the `-m opencode` override and an
+`orcarouter/*` model:
+
+```bash
+ORCAROUTER_API_KEY=sk-orca-… oma agent:spawn pm "Draft the rollout plan" <session> -m opencode
+```
+
+### Per-agent OrcaRouter models
+
+Register an OrcaRouter model under `models:` and reference it from `agents:`.
+The slug must be in `owner/model` form (`orcarouter/auto`, `orcarouter/fusion`).
+
+```yaml
+# .agents/oma-config.yaml
+language: en
+model_preset: mixed
+
+models:
+  orcarouter/auto:
+    cli: opencode
+    cli_model: orcarouter/auto
+    auth_hint: "OrcaRouter API key — https://www.orcarouter.ai"
+    supports:
+      effort: null
+      apply_patch: false
+      task_budget: false
+      prompt_cache: false
+      computer_use: false
+      native_dispatch_from: [opencode]
+      api_only: false
+
+agents:
+  pm:      { model: orcarouter/auto }
+  qa:      { model: orcarouter/auto }
+  docs:    { model: orcarouter/auto }
+  explore: { model: orcarouter/auto }
+```
+
+Each routed agent dispatches `opencode run -m orcarouter/auto --agent <id>
+--dir <workspace> "<prompt>"`. Validate the slug against your installed opencode
+catalog with:
+
+```bash
+oma model:probe orcarouter/auto --json
+```
+
+It also runs gateway-level, zero-trust security for AI agents on the same
+endpoint — screening every prompt/response and governing every tool call on a
+default-deny basis, with no application code changes.
+
+> **Auth:** oma recognizes `ORCAROUTER_API_KEY` as a valid provider key for the
+> pi BYOK transport (`oma auth:status` / `oma doctor`), and `orcarouter/*` model
+> slugs pass through pi's `--model` unchanged.
+


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible gateway that routes to 200+ models under one key (`sk-orca-…`), as a named model owner so `orcarouter/*` slugs resolve through the opencode CLI and the pi BYOK transport.

## What changed

- **`cli/io/runtime-dispatch/pi-model-map.ts`** — add `orcarouter` to `PI_RUNNABLE_PROVIDERS` so `orcarouter/auto` / `orcarouter/fusion` etc. pass through pi's `--model` unchanged (matching the `anthropic`/`openai`/`google` real-provider set).
- **`cli/vendors/pi/auth.ts`** — recognize `ORCAROUTER_API_KEY` as a valid BYOK credential for pi (`oma auth:status` / `oma doctor`).
- **`cli/platform/model-registry.ts`** — `ownerToVendor("orcarouter")` now resolves to the `opencode` CLI (mirroring the `opencode-*` provider-tier rule), and `buildUnknownSlugError` scaffolds an OrcaRouter-aware `models:` entry pointing at `https://api.orcarouter.ai/v1/models`.
- **`web/docs/guide/per-agent-models.md`** — new "Dispatching through OrcaRouter" section with dispatch commands, a `models:` config sample, and probe guidance.

## Verification

```bash
bun run --cwd cli lint           # biome: clean on changed files
bun run typecheck                # tsc: clean (cli + web)
bun run test                     # 4300 passed, 1 pre-existing failure (filter-test-output, fails on clean main too)
bun run --cwd cli check:boundaries
bun run --cwd cli check:emit-drift
```

Manual / integration check: `toPiModel("orcarouter/auto")` returns the slug unchanged, `ownerToVendor("orcarouter")` returns `opencode`, and a live call to `https://api.orcarouter.ai/v1/chat/completions` with `orcarouter/free` returns HTTP 200 with content `ORCA-OK`.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Scope is focused — one logical feature
- [x] Tests added or updated for the new behavior
- [x] `bun run lint` and `bun run test` pass locally
- [x] Docs updated if behavior, flags, config keys, or env vars changed
- [x] No secrets, credentials, or `.env` files committed
- [x] `.agents/` SSOT changes are intentional (source repo only)

## Related issues

None.

---

Disclosure: I'm an engineer on the OrcaRouter team.
